### PR TITLE
Auto Rig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ protox = { version = "0.7", optional = true }
 default = ["ml"]
 ml = ["dep:ort"]
 text-to-motion = ["dep:tonic", "dep:prost", "dep:tokio", "dep:tonic-build", "dep:protox"]
-text-to-mesh = ["text-to-motion"]
+auto-rig = ["text-to-motion"]
 
 [dependencies.gltf]
 version = "1.4"

--- a/proto/animation_ml.proto
+++ b/proto/animation_ml.proto
@@ -129,3 +129,53 @@ message MeshStatusResponse {
     string i2m_model = 3;
     int32 gpu_memory_mb = 4;
 }
+
+enum RiggingModelType {
+    RIGGING_UNIRIG = 0;
+}
+
+service AutoRiggingService {
+    rpc GenerateRig (RiggingRequest) returns (RiggingResponse);
+    rpc GetRiggingStatus (RiggingStatusRequest) returns (RiggingStatusResponse);
+}
+
+message RiggingRequest {
+    bytes glb_data = 1;
+    RiggingParams params = 2;
+    RiggingModelType model_type = 3;
+}
+
+message RiggingParams {
+    int32 num_sample_points = 1;
+}
+
+message SkeletonJoint {
+    string name = 1;
+    float x = 2;
+    float y = 3;
+    float z = 4;
+    float tail_x = 5;
+    float tail_y = 6;
+    float tail_z = 7;
+    int32 parent_index = 8;
+}
+
+message RiggingResponse {
+    bytes rigged_glb_data = 1;
+    RiggingMetadata metadata = 2;
+    repeated SkeletonJoint skeleton_joints = 3;
+}
+
+message RiggingMetadata {
+    int32 joint_count = 1;
+    int32 bone_count = 2;
+    float generation_time_ms = 3;
+}
+
+message RiggingStatusRequest {}
+
+message RiggingStatusResponse {
+    bool ready = 1;
+    string model_name = 2;
+    int32 gpu_memory_mb = 3;
+}

--- a/shaders/gbufferFragment.frag
+++ b/shaders/gbufferFragment.frag
@@ -21,13 +21,19 @@ layout(set = 1, binding = 1) uniform MaterialUBO {
 
 layout(push_constant) uniform PushConstants {
     uint objectID;
+    uint heatmapMode;
 } pc;
 
 void main() {
     vec4 texColor = texture(texSampler, fragTexCoord);
     if (fragColor.a < 0.5) discard;
 
-    vec3 albedoRGB = texColor.rgb * fragColor.rgb * material.base_color.rgb;
+    vec3 albedoRGB;
+    if (pc.heatmapMode == 1u) {
+        albedoRGB = fragColor.rgb;
+    } else {
+        albedoRGB = texColor.rgb * fragColor.rgb * material.base_color.rgb;
+    }
 
     outPosition = vec4(fragWorldPos, 1.0);
     outNormal = vec4(normalize(fragWorldNormal), 1.0);

--- a/src/app/color_test_quad.rs
+++ b/src/app/color_test_quad.rs
@@ -193,6 +193,7 @@ unsafe fn create_quad_mesh_buffer(
         skeleton_id: None,
         node_index: None,
         base_vertices: Vec::new(),
+        base_colors: None,
     })
 }
 

--- a/src/app/init/instance.rs
+++ b/src/app/init/instance.rs
@@ -338,9 +338,13 @@ impl App {
         data.ecs_world
             .insert_resource(crate::ecs::resource::GrpcServerProcess::default());
 
-        #[cfg(feature = "text-to-mesh")]
+        #[cfg(feature = "auto-rig")]
         data.ecs_world
             .insert_resource(crate::ecs::resource::TextToMeshState::default());
+
+        #[cfg(feature = "auto-rig")]
+        data.ecs_world
+            .insert_resource(crate::ecs::resource::AutoRigState::default());
 
         let viewport_width = rrswapchain.swapchain_extent.width;
         let viewport_height = rrswapchain.swapchain_extent.height;

--- a/src/app/init/instance.rs
+++ b/src/app/init/instance.rs
@@ -686,6 +686,8 @@ impl App {
         data.ecs_world.insert_resource(bone_gizmo_data);
         data.ecs_world
             .insert_resource(crate::ecs::resource::gizmo::BoneSelectionState::default());
+        data.ecs_world
+            .insert_resource(crate::ecs::resource::WeightHeatmapState::default());
 
         let mut constraint_gizmo_data = ConstraintGizmoData::default();
         constraint_gizmo_data.wire_render_info.pipeline_id = Some(pipeline_ids.bone_wire);

--- a/src/app/model_loader.rs
+++ b/src/app/model_loader.rs
@@ -514,6 +514,13 @@ unsafe fn create_mesh_buffer(
     mesh.skeleton_id = loaded_mesh.skeleton_id;
     mesh.node_index = loaded_mesh.node_index;
     mesh.base_vertices = loaded_mesh.local_vertices.clone();
+    mesh.base_colors = Some(
+        mesh.vertex_data
+            .vertices
+            .iter()
+            .map(|v| cgmath::Vector4::new(v.color.x, v.color.y, v.color.z, v.color.w))
+            .collect(),
+    );
 
     mesh.vertex_buffer = RRVertexBuffer::new(
         instance,

--- a/src/app/model_loader.rs
+++ b/src/app/model_loader.rs
@@ -54,7 +54,7 @@ pub unsafe fn load_model_from_file_system(
 
     let (load_result, fbx_model) = load_model_data(path)?;
 
-    apply_model_to_resources(
+    let _parent_entity = apply_model_to_resources(
         &load_result,
         path,
         instance,
@@ -73,7 +73,7 @@ pub unsafe fn load_model_from_file_system(
     Ok(())
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub unsafe fn load_model_from_file_system_with_result(
     load_result: &ModelLoadResult,
     model_name: &str,
@@ -87,8 +87,8 @@ pub unsafe fn load_model_from_file_system_with_result(
     assets: &mut AssetStorage,
     scene_will_provide_clips: bool,
     fbx_model: Option<FbxModel>,
-) -> Result<()> {
-    apply_model_to_resources(
+) -> Result<crate::ecs::world::Entity> {
+    let parent_entity = apply_model_to_resources(
         load_result,
         model_name,
         instance,
@@ -104,7 +104,7 @@ pub unsafe fn load_model_from_file_system_with_result(
     )?;
 
     log!("=== Model loaded successfully ===");
-    Ok(())
+    Ok(parent_entity)
 }
 
 unsafe fn load_model_data(path: &str) -> Result<(ModelLoadResult, Option<FbxModel>)> {
@@ -136,7 +136,7 @@ unsafe fn apply_model_to_resources(
     assets: &mut AssetStorage,
     scene_will_provide_clips: bool,
     fbx_model: Option<FbxModel>,
-) -> Result<()> {
+) -> Result<crate::ecs::world::Entity> {
     cleanup_resources(device, graphics, raytracing, world, assets)?;
     insert_model_caches(world, model_name, fbx_model);
     ensure_graphics_capacity(load_result, instance, device, swapchain, graphics)?;
@@ -188,7 +188,7 @@ unsafe fn apply_model_to_resources(
     let node_animation_scale = load_result.node_animation_scale;
     log_model_load_info(load_result, animation_type.clone(), node_animation_scale);
 
-    create_ecs_entities(
+    let parent_entity = create_ecs_entities(
         model_name,
         graphics,
         world,
@@ -198,6 +198,15 @@ unsafe fn apply_model_to_resources(
         &load_result.clips.clone(),
         scene_will_provide_clips,
     );
+
+    let path_lower = model_name.to_lowercase();
+    if path_lower.ends_with(".gltf") || path_lower.ends_with(".glb") || path_lower.ends_with(".fbx")
+    {
+        world.insert_component(
+            parent_entity,
+            crate::ecs::component::GlbSource::FilePath(model_name.to_string()),
+        );
+    }
 
     apply_loaded_constraints(load_result, world);
     apply_loaded_spring_bones(load_result, world);
@@ -210,7 +219,7 @@ unsafe fn apply_model_to_resources(
     );
     initialize_constraint_gizmo_visibility(world);
 
-    Ok(())
+    Ok(parent_entity)
 }
 
 fn insert_model_caches(world: &mut World, model_name: &str, fbx_model: Option<FbxModel>) {
@@ -838,7 +847,7 @@ fn create_ecs_entities(
     node_animation_scale: f32,
     loaded_clips: &[crate::animation::AnimationClip],
     scene_will_provide_clips: bool,
-) {
+) -> crate::ecs::world::Entity {
     let name = std::path::Path::new(model_name)
         .file_stem()
         .and_then(|s| s.to_str())
@@ -895,6 +904,8 @@ fn create_ecs_entities(
         assets.animation_clips.len(),
         assets.nodes.len()
     );
+
+    parent_entity
 }
 
 fn ensure_ecs_resources(world: &mut World) {
@@ -1261,7 +1272,7 @@ pub unsafe fn load_model_additive(
         .unwrap_or("part")
         .to_string();
 
-    append_model_to_scene(
+    let parent_entity = append_model_to_scene(
         &load_result,
         &part_name,
         instance,
@@ -1272,7 +1283,14 @@ pub unsafe fn load_model_additive(
         raytracing,
         world,
         assets,
-    )
+    )?;
+
+    world.insert_component(
+        parent_entity,
+        crate::ecs::component::GlbSource::FilePath(path.to_string()),
+    );
+
+    Ok(())
 }
 
 unsafe fn append_model_to_scene(
@@ -1286,7 +1304,7 @@ unsafe fn append_model_to_scene(
     raytracing: &mut RayTracingData,
     world: &mut World,
     assets: &mut AssetStorage,
-) -> Result<()> {
+) -> Result<crate::ecs::world::Entity> {
     ensure_graphics_capacity(load_result, instance, device, swapchain, graphics)?;
 
     let mesh_index_offset = graphics.meshes.len();
@@ -1355,7 +1373,7 @@ unsafe fn append_model_to_scene(
         world.entity_count()
     );
 
-    Ok(())
+    Ok(parent_entity)
 }
 
 fn build_mesh_entities_range(

--- a/src/app/model_loader.rs
+++ b/src/app/model_loader.rs
@@ -863,14 +863,19 @@ fn create_ecs_entities(
 
     ensure_ecs_resources(world);
 
-    let first_editable_clip_id =
+    let mut first_editable_clip_id =
         register_clips_to_library(world, assets, loaded_clips, scene_will_provide_clips);
 
     register_node_assets(world, assets);
 
-    let has_animation = !loaded_clips.is_empty();
+    if first_editable_clip_id.is_none() && !scene_will_provide_clips && !assets.skeletons.is_empty()
+    {
+        first_editable_clip_id = Some(register_empty_editable_clip(world, assets));
+    }
 
-    let initial_schedule = if has_animation && !scene_will_provide_clips {
+    let has_playable_clip = first_editable_clip_id.is_some();
+
+    let initial_schedule = if has_playable_clip && !scene_will_provide_clips {
         build_initial_clip_schedule(first_editable_clip_id, world)
     } else {
         ClipSchedule::new()
@@ -883,7 +888,7 @@ fn create_ecs_entities(
         .with_visible(true)
         .with_editor_display(EntityIcon::Model, true);
 
-    if has_animation {
+    if has_playable_clip {
         parent_builder = parent_builder
             .with_animator(Animator::new())
             .with_clip_schedule(initial_schedule)
@@ -981,6 +986,34 @@ fn register_clips_to_library(
     }
 
     first_editable_clip_id
+}
+
+const EMPTY_CLIP_DEFAULT_DURATION_SECONDS: f32 = 5.0;
+
+fn register_empty_editable_clip(world: &mut World, assets: &mut AssetStorage) -> SourceClipId {
+    use crate::animation::editable::EditableAnimationClip;
+
+    let mut clip_library = world.resource_mut::<ClipLibrary>();
+    let mut editable = EditableAnimationClip::new(0, "New Animation".to_string());
+    editable.duration = EMPTY_CLIP_DEFAULT_DURATION_SECONDS;
+    let source_id = crate::ecs::systems::clip_library_systems::clip_library_register_and_activate(
+        &mut clip_library,
+        assets,
+        editable,
+    );
+    drop(clip_library);
+
+    let mut timeline_state = world.resource_mut::<TimelineState>();
+    timeline_state.current_clip_id = Some(source_id);
+    drop(timeline_state);
+
+    log!(
+        "Auto-created empty animation clip 'New Animation' (source_id={}, duration={}s) for model with no animations",
+        source_id,
+        EMPTY_CLIP_DEFAULT_DURATION_SECONDS
+    );
+
+    source_id
 }
 
 fn register_node_assets(world: &World, assets: &mut AssetStorage) {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -250,7 +250,7 @@ impl App {
         Ok(())
     }
 
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     pub unsafe fn load_model_from_glb(&mut self, glb_data: &[u8]) -> Result<()> {
         log!("Loading generated mesh from GLB ({} bytes)", glb_data.len());
         self.rrdevice.device.device_wait_idle()?;
@@ -274,7 +274,7 @@ impl App {
             false,
             None,
         ) {
-            Ok(_) => {
+            Ok(parent_entity) => {
                 {
                     let mut model_state = self
                         .data
@@ -300,6 +300,10 @@ impl App {
                         crate::ecs::resource::GltfModelCache::from_glb_data(glb_data.to_vec());
                     self.data.ecs_world.insert_resource(cache);
                 }
+                self.data.ecs_world.insert_component(
+                    parent_entity,
+                    crate::ecs::component::GlbSource::InMemory(glb_data.to_vec()),
+                );
 
                 msg_info!("Generated mesh loaded successfully");
             }

--- a/src/ecs/component/glb_source.rs
+++ b/src/ecs/component/glb_source.rs
@@ -1,0 +1,14 @@
+#[derive(Clone)]
+pub enum GlbSource {
+    FilePath(String),
+    InMemory(Vec<u8>),
+}
+
+impl GlbSource {
+    pub fn read_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        match self {
+            GlbSource::FilePath(path) => std::fs::read(path).map_err(|e| e.into()),
+            GlbSource::InMemory(data) => Ok(data.clone()),
+        }
+    }
+}

--- a/src/ecs/component/mod.rs
+++ b/src/ecs/component/mod.rs
@@ -5,6 +5,7 @@ mod constraint_set;
 mod core;
 mod editor;
 mod gizmo;
+mod glb_source;
 #[cfg(feature = "ml")]
 mod inference_actor;
 mod marker;
@@ -19,6 +20,7 @@ pub use constraint_set::*;
 pub use core::*;
 pub use editor::*;
 pub use gizmo::*;
+pub use glb_source::*;
 #[cfg(feature = "ml")]
 pub use inference_actor::*;
 pub use marker::*;

--- a/src/ecs/events/ui_events.rs
+++ b/src/ecs/events/ui_events.rs
@@ -346,7 +346,7 @@ pub enum UIEvent {
     #[cfg(feature = "text-to-motion")]
     TextToMotionCancel,
 
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     TextToMeshGenerate {
         prompt: String,
         target_faces: u32,
@@ -356,10 +356,19 @@ pub enum UIEvent {
         model_type: crate::grpc::MeshModelType,
         t2i_model_type: crate::grpc::TextToImageModelType,
     },
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     TextToMeshApply,
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     TextToMeshCancel,
+
+    #[cfg(feature = "auto-rig")]
+    AutoRigGenerate {
+        num_sample_points: u32,
+    },
+    #[cfg(feature = "auto-rig")]
+    AutoRigApply,
+    #[cfg(feature = "auto-rig")]
+    AutoRigDiscard,
 
     ExportModelGltf,
 

--- a/src/ecs/events/ui_events.rs
+++ b/src/ecs/events/ui_events.rs
@@ -380,6 +380,7 @@ pub enum UIEvent {
     },
 
     SetBoneGizmoVisible(bool),
+    SetWeightHeatmapEnabled(bool),
     SetTransformGizmoMode(TransformGizmoMode),
     SetTransformGizmoSpace(CoordinateSpace),
     UpdateTransformGizmoState(Box<TransformGizmoState>),

--- a/src/ecs/resource/auto_rig_state.rs
+++ b/src/ecs/resource/auto_rig_state.rs
@@ -1,0 +1,42 @@
+use std::time::Instant;
+
+use crate::ecs::world::Entity;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AutoRigStatus {
+    Idle,
+    WaitingForServer,
+    Rigging,
+    Previewing,
+    Error,
+}
+
+pub struct AutoRigState {
+    pub status: AutoRigStatus,
+    pub rigged_glb_data: Option<Vec<u8>>,
+    pub error_message: Option<String>,
+    pub joint_count: Option<u32>,
+    pub bone_count: Option<u32>,
+    pub generation_time_ms: Option<f32>,
+    pub source_glb_data: Option<Vec<u8>>,
+    pub original_glb_backup: Option<Vec<u8>>,
+    pub target_entity: Option<Entity>,
+    pub last_status_check: Option<Instant>,
+}
+
+impl Default for AutoRigState {
+    fn default() -> Self {
+        Self {
+            status: AutoRigStatus::Idle,
+            rigged_glb_data: None,
+            error_message: None,
+            joint_count: None,
+            bone_count: None,
+            generation_time_ms: None,
+            source_glb_data: None,
+            original_glb_backup: None,
+            target_entity: None,
+            last_status_check: None,
+        }
+    }
+}

--- a/src/ecs/resource/mod.rs
+++ b/src/ecs/resource/mod.rs
@@ -60,6 +60,7 @@ mod timeline_state;
 mod tone_mapping;
 mod transform_gizmo_state;
 mod view_mode;
+mod weight_heatmap;
 
 pub use billboard::*;
 pub use gizmo::*;
@@ -123,3 +124,4 @@ pub use timeline_state::*;
 pub use tone_mapping::*;
 pub use transform_gizmo_state::*;
 pub use view_mode::*;
+pub use weight_heatmap::*;

--- a/src/ecs/resource/mod.rs
+++ b/src/ecs/resource/mod.rs
@@ -7,6 +7,8 @@ mod mouse_input;
 mod viewport_input;
 
 mod auto_exposure;
+#[cfg(feature = "auto-rig")]
+mod auto_rig_state;
 mod bloom;
 #[cfg(feature = "ml")]
 mod bone_name_token_cache;
@@ -49,7 +51,7 @@ mod projection_data;
 mod scene_state;
 mod spring_bone_editor_state;
 mod spring_bone_state;
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 mod text_to_mesh_state;
 #[cfg(feature = "text-to-motion")]
 mod text_to_motion_state;
@@ -68,6 +70,8 @@ pub use mouse_input::*;
 pub use viewport_input::*;
 
 pub use auto_exposure::*;
+#[cfg(feature = "auto-rig")]
+pub use auto_rig_state::*;
 pub use bloom::*;
 #[cfg(feature = "ml")]
 pub use bone_name_token_cache::*;
@@ -110,7 +114,7 @@ pub use projection_data::*;
 pub use scene_state::*;
 pub use spring_bone_editor_state::*;
 pub use spring_bone_state::*;
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub use text_to_mesh_state::*;
 #[cfg(feature = "text-to-motion")]
 pub use text_to_motion_state::*;

--- a/src/ecs/resource/weight_heatmap.rs
+++ b/src/ecs/resource/weight_heatmap.rs
@@ -1,0 +1,29 @@
+use crate::animation::BoneId;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HeatmapApplication {
+    NotApplied,
+    Applied(Option<BoneId>),
+}
+
+impl Default for HeatmapApplication {
+    fn default() -> Self {
+        Self::NotApplied
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct WeightHeatmapState {
+    pub enabled: bool,
+    last_applied: HeatmapApplication,
+}
+
+impl WeightHeatmapState {
+    pub fn last_applied(&self) -> &HeatmapApplication {
+        &self.last_applied
+    }
+
+    pub fn set_last_applied(&mut self, state: HeatmapApplication) {
+        self.last_applied = state;
+    }
+}

--- a/src/ecs/systems/auto_rig_systems.rs
+++ b/src/ecs/systems/auto_rig_systems.rs
@@ -1,0 +1,46 @@
+use crate::ecs::resource::{AutoRigState, AutoRigStatus};
+use crate::ecs::world::Entity;
+use crate::grpc::{GrpcRequest, GrpcThreadHandle};
+
+pub fn auto_rig_submit(
+    state: &mut AutoRigState,
+    handle: &GrpcThreadHandle,
+    source_glb_data: Vec<u8>,
+    target_entity: Entity,
+) {
+    state.status = AutoRigStatus::WaitingForServer;
+    state.rigged_glb_data = None;
+    state.error_message = None;
+    state.joint_count = None;
+    state.bone_count = None;
+    state.generation_time_ms = None;
+    state.source_glb_data = Some(source_glb_data);
+    state.target_entity = Some(target_entity);
+    state.last_status_check = None;
+
+    handle.send(GrpcRequest::CheckRiggingStatus);
+}
+
+pub fn auto_rig_send_generate(state: &mut AutoRigState, handle: &GrpcThreadHandle) {
+    let glb_data = match state.source_glb_data.take() {
+        Some(data) => data,
+        None => return,
+    };
+
+    state.status = AutoRigStatus::Rigging;
+
+    handle.send(GrpcRequest::GenerateRig(crate::grpc::RiggingRequest {
+        glb_data,
+        num_sample_points: 65536,
+    }));
+}
+
+pub fn auto_rig_cancel(state: &mut AutoRigState) {
+    state.status = AutoRigStatus::Idle;
+    state.rigged_glb_data = None;
+    state.error_message = None;
+    state.source_glb_data = None;
+    state.original_glb_backup = None;
+    state.target_entity = None;
+    state.last_status_check = None;
+}

--- a/src/ecs/systems/bone_gizmo_systems.rs
+++ b/src/ecs/systems/bone_gizmo_systems.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
-use cgmath::{Matrix4, SquareMatrix, Vector3, Vector4};
+use cgmath::{InnerSpace, Matrix4, SquareMatrix, Vector3, Vector4};
 
 use crate::animation::Skeleton;
 use crate::ecs::component::{ColorVertex, LineMesh};
 use crate::ecs::resource::gizmo::{BoneGizmoData, BoneSelectionState};
-use crate::math::ray_to_triangle_intersection;
+use crate::ecs::resource::MeshAssets;
+use crate::math::{ray_to_triangle_barycentric, ray_to_triangle_intersection};
 use crate::render::RenderBackend;
 
 const BONE_LINE_COLOR: [f32; 3] = [0.0, 0.8, 0.0];
@@ -518,6 +519,150 @@ pub unsafe fn update_bone_gizmo_buffers(
     backend.update_or_create_line_buffers(&mut bone_gizmo.stick_mesh)
 }
 
+pub fn select_bone_by_mesh_ray(
+    ray_origin_world: Vector3<f32>,
+    ray_direction_world: Vector3<f32>,
+    mesh_assets: &MeshAssets,
+    entity_world_transform: Matrix4<f32>,
+) -> Option<(usize, f32)> {
+    let inv_world = entity_world_transform.invert()?;
+    let (ray_origin, ray_direction) =
+        transform_ray_to_local(&inv_world, ray_origin_world, ray_direction_world);
+
+    let hit = find_closest_triangle_hit(mesh_assets, ray_origin, ray_direction)?;
+
+    let mesh = &mesh_assets.meshes[hit.mesh_index];
+    let skin = mesh.skin_data.as_ref()?;
+    let bone_index = pick_dominant_bone_from_triangle(skin, &hit)?;
+
+    Some((bone_index, hit.t_world))
+}
+
+struct MeshTriangleHit {
+    mesh_index: usize,
+    vertex_indices: [usize; 3],
+    barycentric: [f32; 3],
+    t_world: f32,
+}
+
+fn transform_ray_to_local(
+    inv_world: &Matrix4<f32>,
+    ray_origin_world: Vector3<f32>,
+    ray_direction_world: Vector3<f32>,
+) -> (Vector3<f32>, Vector3<f32>) {
+    let o = inv_world
+        * Vector4::new(
+            ray_origin_world.x,
+            ray_origin_world.y,
+            ray_origin_world.z,
+            1.0,
+        );
+    let d = inv_world
+        * Vector4::new(
+            ray_direction_world.x,
+            ray_direction_world.y,
+            ray_direction_world.z,
+            0.0,
+        );
+
+    (Vector3::new(o.x, o.y, o.z), Vector3::new(d.x, d.y, d.z))
+}
+
+fn find_closest_triangle_hit(
+    mesh_assets: &MeshAssets,
+    ray_origin_local: Vector3<f32>,
+    ray_direction_local: Vector3<f32>,
+) -> Option<MeshTriangleHit> {
+    let direction_length = ray_direction_local.dot(ray_direction_local).sqrt();
+    if direction_length < f32::EPSILON {
+        return None;
+    }
+
+    let mut best: Option<MeshTriangleHit> = None;
+
+    for (mesh_index, mesh) in mesh_assets.meshes.iter().enumerate() {
+        if mesh.skin_data.is_none() {
+            continue;
+        }
+        let vertices = &mesh.vertex_data.vertices;
+        let indices = &mesh.vertex_data.indices;
+        if vertices.is_empty() || indices.len() < 3 {
+            continue;
+        }
+
+        for tri in indices.chunks_exact(3) {
+            let i0 = tri[0] as usize;
+            let i1 = tri[1] as usize;
+            let i2 = tri[2] as usize;
+            if i0 >= vertices.len() || i1 >= vertices.len() || i2 >= vertices.len() {
+                continue;
+            }
+
+            let p0 = vertex_position(&vertices[i0]);
+            let p1 = vertex_position(&vertices[i1]);
+            let p2 = vertex_position(&vertices[i2]);
+
+            let Some((t_local, u, v)) =
+                ray_to_triangle_barycentric(ray_origin_local, ray_direction_local, p0, p1, p2)
+            else {
+                continue;
+            };
+
+            let t_world = t_local * direction_length;
+            let is_closer = best.as_ref().map_or(true, |h| t_world < h.t_world);
+            if is_closer {
+                best = Some(MeshTriangleHit {
+                    mesh_index,
+                    vertex_indices: [i0, i1, i2],
+                    barycentric: [1.0 - u - v, u, v],
+                    t_world,
+                });
+            }
+        }
+    }
+
+    best
+}
+
+fn vertex_position(vertex: &crate::vulkanr::data::Vertex) -> Vector3<f32> {
+    Vector3::new(vertex.pos.x, vertex.pos.y, vertex.pos.z)
+}
+
+fn pick_dominant_bone_from_triangle(
+    skin: &crate::animation::SkinData,
+    hit: &MeshTriangleHit,
+) -> Option<usize> {
+    let mut accumulated: std::collections::HashMap<u32, f32> = std::collections::HashMap::new();
+
+    for (slot, &vertex_index) in hit.vertex_indices.iter().enumerate() {
+        if vertex_index >= skin.bone_indices.len() || vertex_index >= skin.bone_weights.len() {
+            continue;
+        }
+        let bary_weight = hit.barycentric[slot];
+        let indices = &skin.bone_indices[vertex_index];
+        let weights = &skin.bone_weights[vertex_index];
+
+        let influences = [
+            (indices.x, weights.x),
+            (indices.y, weights.y),
+            (indices.z, weights.z),
+            (indices.w, weights.w),
+        ];
+
+        for (bone_id, weight) in influences {
+            if weight <= 0.0 {
+                continue;
+            }
+            *accumulated.entry(bone_id).or_insert(0.0) += bary_weight * weight;
+        }
+    }
+
+    accumulated
+        .into_iter()
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(bone_id, _)| bone_id as usize)
+}
+
 pub fn build_box_bone_meshes_with_selection(
     skeleton: &Skeleton,
     global_transforms: &[Matrix4<f32>],
@@ -845,7 +990,139 @@ mod tests {
     use crate::animation::SkinData;
     use crate::ecs::{apply_skinning, compute_pose_global_transforms, create_pose_from_rest};
     use crate::loader::{LoadedNode, ModelLoadResult};
-    use cgmath::InnerSpace;
+    use crate::vulkanr::data::{Vertex, VertexData};
+    use crate::vulkanr::resource::graphics_resource::MeshBuffer;
+
+    fn make_mesh_buffer_single_triangle(
+        bone_indices: [[u32; 4]; 3],
+        bone_weights: [[f32; 4]; 3],
+        positions: [Vector3<f32>; 3],
+    ) -> MeshBuffer {
+        let mut mesh = MeshBuffer::default();
+        let mut vertex_data = VertexData::default();
+        for p in &positions {
+            let mut v = Vertex::default();
+            v.pos.x = p.x;
+            v.pos.y = p.y;
+            v.pos.z = p.z;
+            vertex_data.vertices.push(v);
+        }
+        vertex_data.indices = vec![0, 1, 2];
+        mesh.vertex_data = vertex_data;
+
+        let mut skin = SkinData::default();
+        skin.bone_indices = bone_indices
+            .iter()
+            .map(|bi| cgmath::Vector4::new(bi[0], bi[1], bi[2], bi[3]))
+            .collect();
+        skin.bone_weights = bone_weights
+            .iter()
+            .map(|bw| cgmath::Vector4::new(bw[0], bw[1], bw[2], bw[3]))
+            .collect();
+        skin.base_positions = positions.to_vec();
+        mesh.skin_data = Some(skin);
+
+        mesh
+    }
+
+    #[test]
+    fn select_bone_by_mesh_ray_picks_dominant_bone_on_centroid_hit() {
+        let mesh = make_mesh_buffer_single_triangle(
+            [[5, 0, 0, 0], [5, 0, 0, 0], [5, 0, 0, 0]],
+            [[1.0, 0.0, 0.0, 0.0]; 3],
+            [
+                Vector3::new(-1.0, -1.0, 0.0),
+                Vector3::new(1.0, -1.0, 0.0),
+                Vector3::new(0.0, 1.0, 0.0),
+            ],
+        );
+        let mesh_assets = MeshAssets { meshes: vec![mesh] };
+
+        let ray_origin = Vector3::new(0.0, 0.0, 5.0);
+        let ray_direction = Vector3::new(0.0, 0.0, -1.0);
+
+        let hit =
+            select_bone_by_mesh_ray(ray_origin, ray_direction, &mesh_assets, Matrix4::identity());
+
+        let (bone_index, _t) = hit.expect("expected a mesh ray hit");
+        assert_eq!(
+            bone_index, 5,
+            "all vertices weighted to bone 5, expected selection"
+        );
+    }
+
+    #[test]
+    fn select_bone_by_mesh_ray_uses_barycentric_weighting() {
+        let mesh = make_mesh_buffer_single_triangle(
+            [[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]],
+            [[1.0, 0.0, 0.0, 0.0]; 3],
+            [
+                Vector3::new(-1.0, -1.0, 0.0),
+                Vector3::new(1.0, -1.0, 0.0),
+                Vector3::new(0.0, 1.0, 0.0),
+            ],
+        );
+        let mesh_assets = MeshAssets { meshes: vec![mesh] };
+
+        let ray_origin = Vector3::new(0.9, -0.9, 5.0);
+        let ray_direction = Vector3::new(0.0, 0.0, -1.0);
+
+        let hit =
+            select_bone_by_mesh_ray(ray_origin, ray_direction, &mesh_assets, Matrix4::identity());
+
+        let (bone_index, _t) = hit.expect("expected a mesh ray hit near vertex 1");
+        assert_eq!(
+            bone_index, 2,
+            "hit near vertex 1 (bone 2), expected dominant bone 2"
+        );
+    }
+
+    #[test]
+    fn select_bone_by_mesh_ray_returns_none_when_ray_misses_mesh() {
+        let mesh = make_mesh_buffer_single_triangle(
+            [[1, 0, 0, 0]; 3],
+            [[1.0, 0.0, 0.0, 0.0]; 3],
+            [
+                Vector3::new(-1.0, -1.0, 0.0),
+                Vector3::new(1.0, -1.0, 0.0),
+                Vector3::new(0.0, 1.0, 0.0),
+            ],
+        );
+        let mesh_assets = MeshAssets { meshes: vec![mesh] };
+
+        let ray_origin = Vector3::new(10.0, 10.0, 5.0);
+        let ray_direction = Vector3::new(0.0, 0.0, -1.0);
+
+        let hit =
+            select_bone_by_mesh_ray(ray_origin, ray_direction, &mesh_assets, Matrix4::identity());
+
+        assert!(hit.is_none(), "ray outside triangle should not hit");
+    }
+
+    #[test]
+    fn select_bone_by_mesh_ray_applies_entity_world_transform() {
+        let mesh = make_mesh_buffer_single_triangle(
+            [[7, 0, 0, 0]; 3],
+            [[1.0, 0.0, 0.0, 0.0]; 3],
+            [
+                Vector3::new(-1.0, -1.0, 0.0),
+                Vector3::new(1.0, -1.0, 0.0),
+                Vector3::new(0.0, 1.0, 0.0),
+            ],
+        );
+        let mesh_assets = MeshAssets { meshes: vec![mesh] };
+
+        let entity_transform = Matrix4::from_translation(Vector3::new(100.0, 0.0, 0.0));
+
+        let ray_origin = Vector3::new(100.0, 0.0, 5.0);
+        let ray_direction = Vector3::new(0.0, 0.0, -1.0);
+
+        let hit =
+            select_bone_by_mesh_ray(ray_origin, ray_direction, &mesh_assets, entity_transform);
+
+        let (bone_index, _t) = hit.expect("expected mesh hit after applying entity transform");
+        assert_eq!(bone_index, 7);
+    }
 
     fn load_stickman() -> Option<ModelLoadResult> {
         let path = "assets/models/stickman/stickman.glb";

--- a/src/ecs/systems/mod.rs
+++ b/src/ecs/systems/mod.rs
@@ -53,6 +53,7 @@ mod text_to_motion_systems;
 mod timeline_systems;
 pub mod transform_gizmo_systems;
 mod ui_event_systems;
+mod weight_heatmap_systems;
 
 pub use animation::*;
 #[cfg(feature = "auto-rig")]
@@ -100,3 +101,4 @@ pub use text_to_motion_systems::*;
 pub use timeline_systems::*;
 pub use transform_gizmo_systems::*;
 pub use ui_event_systems::*;
+pub use weight_heatmap_systems::*;

--- a/src/ecs/systems/mod.rs
+++ b/src/ecs/systems/mod.rs
@@ -1,5 +1,7 @@
 pub mod animation;
 pub mod animation_debug_dump;
+#[cfg(feature = "auto-rig")]
+mod auto_rig_systems;
 mod billboard_systems;
 mod bone_gizmo_systems;
 mod bone_pose_override_systems;
@@ -44,7 +46,7 @@ pub mod spring_bone_bake_systems;
 pub mod spring_bone_edit_systems;
 mod spring_bone_gizmo_systems;
 mod spring_bone_systems;
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 mod text_to_mesh_systems;
 #[cfg(feature = "text-to-motion")]
 mod text_to_motion_systems;
@@ -53,6 +55,8 @@ pub mod transform_gizmo_systems;
 mod ui_event_systems;
 
 pub use animation::*;
+#[cfg(feature = "auto-rig")]
+pub use auto_rig_systems::*;
 pub use billboard_systems::*;
 pub use bone_gizmo_systems::*;
 pub use bone_pose_override_systems::*;
@@ -89,7 +93,7 @@ pub use render_data_systems::*;
 pub use skeleton_pose_systems::*;
 pub use spring_bone_gizmo_systems::*;
 pub use spring_bone_systems::*;
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub use text_to_mesh_systems::*;
 #[cfg(feature = "text-to-motion")]
 pub use text_to_motion_systems::*;

--- a/src/ecs/systems/phases/animation_phase.rs
+++ b/src/ecs/systems/phases/animation_phase.rs
@@ -4,10 +4,11 @@ use anyhow::Result;
 
 use crate::animation::{BoneId, BoneLocalPose};
 use crate::app::FrameContext;
-use crate::ecs::resource::gizmo::BoneGizmoData;
-use crate::ecs::resource::{BonePoseOverride, ClipLibrary, NodeAssets};
+use crate::ecs::resource::gizmo::{BoneGizmoData, BoneSelectionState};
+use crate::ecs::resource::{BonePoseOverride, ClipLibrary, NodeAssets, WeightHeatmapState};
 use crate::ecs::{
     playback_upload_animations, run_animation_pipeline, transform_propagation_system,
+    update_weight_heatmap,
 };
 
 pub struct AnimationUpdates {
@@ -59,9 +60,29 @@ pub fn run_animation_phase_ecs(ctx: &mut FrameContext) -> AnimationUpdates {
         }
     }
 
-    AnimationUpdates {
-        updated_meshes: eval_result.updated_meshes,
+    let heatmap_updated_meshes = apply_weight_heatmap_update(ctx);
+
+    let mut updated_meshes = eval_result.updated_meshes;
+    for mesh_index in heatmap_updated_meshes {
+        if !updated_meshes.contains(&mesh_index) {
+            updated_meshes.push(mesh_index);
+        }
     }
+
+    AnimationUpdates { updated_meshes }
+}
+
+fn apply_weight_heatmap_update(ctx: &mut FrameContext) -> Vec<usize> {
+    let selection = match ctx.world.get_resource::<BoneSelectionState>() {
+        Some(state) => state.clone(),
+        None => return Vec::new(),
+    };
+
+    let Some(mut heatmap) = ctx.world.get_resource_mut::<WeightHeatmapState>() else {
+        return Vec::new();
+    };
+
+    update_weight_heatmap(ctx.graphics, &mut heatmap, &selection)
 }
 
 fn find_skin_entity_transform(world: &crate::ecs::World) -> cgmath::Matrix4<f32> {

--- a/src/ecs/systems/phases/dispatch_ml.rs
+++ b/src/ecs/systems/phases/dispatch_ml.rs
@@ -188,7 +188,7 @@ pub fn drain_grpc_responses(
                 apply_motion_response(world, assets, curves, generation_time_ms, model_used);
             }
 
-            #[cfg(feature = "text-to-mesh")]
+            #[cfg(feature = "auto-rig")]
             GrpcResponse::MeshGenerated {
                 glb_data,
                 vertex_count,
@@ -218,9 +218,31 @@ pub fn drain_grpc_responses(
                 }
             }
 
-            #[cfg(feature = "text-to-mesh")]
+            #[cfg(feature = "auto-rig")]
             GrpcResponse::MeshServerStatus { ready } => {
                 handle_mesh_server_status(world, ready);
+            }
+
+            #[cfg(feature = "auto-rig")]
+            GrpcResponse::RigGenerated {
+                rigged_glb_data,
+                joint_count,
+                bone_count,
+                generation_time_ms,
+                ..
+            } => {
+                apply_rig_response(
+                    world,
+                    rigged_glb_data,
+                    joint_count,
+                    bone_count,
+                    generation_time_ms,
+                );
+            }
+
+            #[cfg(feature = "auto-rig")]
+            GrpcResponse::RiggingServerStatus { ready, .. } => {
+                handle_rigging_server_status(world, ready);
             }
 
             GrpcResponse::Error { message } => {
@@ -271,7 +293,7 @@ fn apply_motion_response(
     state.model_used = Some(model_used);
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 fn apply_mesh_response(
     world: &mut crate::ecs::world::World,
     glb_data: Vec<u8>,
@@ -318,7 +340,7 @@ fn apply_mesh_response(
     state.intermediate_image_png = intermediate_image_png;
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 fn handle_mesh_server_status(world: &mut crate::ecs::world::World, ready: bool) {
     use crate::ecs::resource::{TextToMeshState, TextToMeshStatus};
     use crate::grpc::GrpcThreadHandle;
@@ -342,7 +364,7 @@ fn handle_mesh_server_status(world: &mut crate::ecs::world::World, ready: bool) 
     }
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub fn poll_mesh_server_status(world: &mut crate::ecs::world::World) {
     use crate::ecs::resource::{TextToMeshState, TextToMeshStatus};
     use crate::grpc::{GrpcRequest, GrpcThreadHandle};
@@ -382,7 +404,7 @@ fn route_grpc_error(world: &mut crate::ecs::world::World, message: &str) {
         }
     }
 
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     {
         use crate::ecs::resource::{TextToMeshState, TextToMeshStatus};
         if let Some(mut state) = world.get_resource_mut::<TextToMeshState>() {
@@ -393,6 +415,22 @@ fn route_grpc_error(world: &mut crate::ecs::world::World, message: &str) {
                 state.status = TextToMeshStatus::Error;
                 state.error_message = Some(message.to_string());
                 state.pending_request = None;
+                return;
+            }
+        }
+    }
+
+    #[cfg(feature = "auto-rig")]
+    {
+        use crate::ecs::resource::{AutoRigState, AutoRigStatus};
+        if let Some(mut state) = world.get_resource_mut::<AutoRigState>() {
+            if state.status == AutoRigStatus::Rigging
+                || state.status == AutoRigStatus::WaitingForServer
+            {
+                log_error!("AutoRig: error - {}", message);
+                state.status = AutoRigStatus::Error;
+                state.error_message = Some(message.to_string());
+                state.source_glb_data = None;
                 return;
             }
         }
@@ -410,7 +448,7 @@ fn truncate_prompt(prompt: &str, max_len: usize) -> String {
     }
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub fn dispatch_text_to_mesh_events(
     events: &[crate::ecs::events::UIEvent],
     world: &mut crate::ecs::world::World,
@@ -483,7 +521,215 @@ pub fn dispatch_text_to_mesh_events(
     }
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
+fn apply_rig_response(
+    world: &mut crate::ecs::world::World,
+    rigged_glb_data: Vec<u8>,
+    joint_count: u32,
+    bone_count: u32,
+    generation_time_ms: f32,
+) {
+    use crate::ecs::resource::{AutoRigState, AutoRigStatus};
+
+    let mut state = world.resource_mut::<AutoRigState>();
+    if state.status != AutoRigStatus::Rigging {
+        return;
+    }
+
+    log!(
+        "AutoRig: received rigged GLB ({} bytes, {} joints, {} bones) in {:.0}ms",
+        rigged_glb_data.len(),
+        joint_count,
+        bone_count,
+        generation_time_ms
+    );
+
+    state.joint_count = Some(joint_count);
+    state.bone_count = Some(bone_count);
+    state.generation_time_ms = Some(generation_time_ms);
+    state.rigged_glb_data = Some(rigged_glb_data);
+    state.status = AutoRigStatus::Previewing;
+}
+
+#[cfg(feature = "auto-rig")]
+fn handle_rigging_server_status(world: &mut crate::ecs::world::World, ready: bool) {
+    use crate::ecs::resource::{AutoRigState, AutoRigStatus};
+    use crate::grpc::GrpcThreadHandle;
+
+    let mut state = world.resource_mut::<AutoRigState>();
+    if state.status != AutoRigStatus::WaitingForServer {
+        return;
+    }
+
+    if ready {
+        log!("AutoRig: server ready, submitting rig request");
+        drop(state);
+
+        let handle = world.get_resource::<GrpcThreadHandle>();
+        let mut state = world.resource_mut::<AutoRigState>();
+        if let Some(handle) = handle {
+            crate::ecs::systems::auto_rig_send_generate(&mut state, &*handle);
+        }
+    } else {
+        state.last_status_check = Some(std::time::Instant::now());
+    }
+}
+
+#[cfg(feature = "auto-rig")]
+pub fn poll_rigging_server_status(world: &mut crate::ecs::world::World) {
+    use crate::ecs::resource::{AutoRigState, AutoRigStatus};
+    use crate::grpc::{GrpcRequest, GrpcThreadHandle};
+
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+    let state = world.resource::<AutoRigState>();
+    if state.status != AutoRigStatus::WaitingForServer {
+        return;
+    }
+
+    let should_poll = match state.last_status_check {
+        Some(last) => last.elapsed() >= POLL_INTERVAL,
+        None => false,
+    };
+    drop(state);
+
+    if !should_poll {
+        return;
+    }
+
+    if let Some(handle) = world.get_resource::<GrpcThreadHandle>() {
+        handle.send(GrpcRequest::CheckRiggingStatus);
+    }
+}
+
+#[cfg(feature = "auto-rig")]
+pub fn dispatch_auto_rig_events(
+    events: &[crate::ecs::events::UIEvent],
+    world: &mut crate::ecs::world::World,
+    deferred: &mut Vec<super::super::ui_event_systems::DeferredAction>,
+) {
+    use crate::ecs::component::GlbSource;
+    use crate::ecs::events::UIEvent;
+    use crate::ecs::resource::{AutoRigState, AutoRigStatus, HierarchyState};
+    use crate::ecs::systems::{auto_rig_cancel, auto_rig_submit};
+    use crate::ecs::world::Parent;
+    use crate::grpc::GrpcThreadHandle;
+
+    const DEFAULT_ENDPOINT: &str = "http://localhost:50051";
+
+    for event in events {
+        match event {
+            UIEvent::AutoRigGenerate { .. } => {
+                let hierarchy = world.resource::<HierarchyState>();
+                let selected = hierarchy.selected_entity;
+                drop(hierarchy);
+
+                let selected_entity = match selected {
+                    Some(e) => e,
+                    None => continue,
+                };
+
+                let parent_entity = resolve_parent_with_glb_source(world, selected_entity);
+                let parent_entity = match parent_entity {
+                    Some(e) => e,
+                    None => {
+                        log_warn!("AutoRig: selected entity has no GlbSource");
+                        continue;
+                    }
+                };
+
+                let glb_source = world.get_component::<GlbSource>(parent_entity);
+                let glb_data = match glb_source {
+                    Some(source) => match source.read_bytes() {
+                        Ok(data) => data,
+                        Err(e) => {
+                            log_error!("AutoRig: failed to read GLB: {}", e);
+                            continue;
+                        }
+                    },
+                    None => continue,
+                };
+
+                if !world.contains_resource::<GrpcThreadHandle>() {
+                    ensure_mesh_server_running(world);
+                    let handle = GrpcThreadHandle::spawn(DEFAULT_ENDPOINT);
+                    world.insert_resource(handle);
+                    log!("AutoRig: spawned gRPC thread ({})", DEFAULT_ENDPOINT);
+                }
+
+                let handle = world.get_resource::<GrpcThreadHandle>();
+                let mut state = world.resource_mut::<AutoRigState>();
+
+                if let Some(handle) = handle {
+                    state.original_glb_backup = Some(glb_data.clone());
+                    auto_rig_submit(&mut state, &*handle, glb_data, parent_entity);
+                }
+            }
+
+            UIEvent::AutoRigApply => {
+                let mut state = world.resource_mut::<AutoRigState>();
+                if state.status != AutoRigStatus::Previewing {
+                    continue;
+                }
+
+                if let Some(rigged_glb) = state.rigged_glb_data.take() {
+                    state.status = AutoRigStatus::Idle;
+                    state.original_glb_backup = None;
+                    state.target_entity = None;
+                    deferred.push(
+                        super::super::ui_event_systems::DeferredAction::LoadModelFromMemory {
+                            glb_data: rigged_glb,
+                        },
+                    );
+                    log!("AutoRig: applying rigged model to scene");
+                }
+            }
+
+            UIEvent::AutoRigDiscard => {
+                let mut state = world.resource_mut::<AutoRigState>();
+                if state.status == AutoRigStatus::Previewing {
+                    if let Some(original_glb) = state.original_glb_backup.take() {
+                        auto_rig_cancel(&mut state);
+                        deferred.push(
+                            super::super::ui_event_systems::DeferredAction::LoadModelFromMemory {
+                                glb_data: original_glb,
+                            },
+                        );
+                        log!("AutoRig: discarding, reverting to original model");
+                        continue;
+                    }
+                }
+                auto_rig_cancel(&mut state);
+                log!("AutoRig: cancelled");
+            }
+
+            _ => {}
+        }
+    }
+}
+
+#[cfg(feature = "auto-rig")]
+fn resolve_parent_with_glb_source(
+    world: &crate::ecs::world::World,
+    entity: crate::ecs::world::Entity,
+) -> Option<crate::ecs::world::Entity> {
+    use crate::ecs::component::GlbSource;
+    use crate::ecs::world::Parent;
+
+    if world.get_component::<GlbSource>(entity).is_some() {
+        return Some(entity);
+    }
+
+    if let Some(Parent(parent)) = world.get_component::<Parent>(entity) {
+        if world.get_component::<GlbSource>(*parent).is_some() {
+            return Some(*parent);
+        }
+    }
+
+    None
+}
+
+#[cfg(feature = "auto-rig")]
 fn ensure_mesh_server_running(world: &mut crate::ecs::world::World) {
     use crate::grpc::MeshServerProcess;
 

--- a/src/ecs/systems/phases/dispatch_overlay.rs
+++ b/src/ecs/systems/phases/dispatch_overlay.rs
@@ -2,7 +2,7 @@ use crate::ecs::events::UIEvent;
 use crate::ecs::resource::gizmo::BoneGizmoData;
 use crate::ecs::resource::{
     AutoExposure, DepthOfField, GridMeshData, HierarchyState, MessageLog, OnionSkinningConfig,
-    PhysicalCameraParameters, TransformGizmoState,
+    PhysicalCameraParameters, TransformGizmoState, WeightHeatmapState,
 };
 use crate::ecs::world::{Animator, World};
 
@@ -12,6 +12,14 @@ pub fn dispatch_overlay_events(events: &[UIEvent], world: &mut World) {
             UIEvent::SetBoneGizmoVisible(visible) => {
                 if let Some(mut gizmo) = world.get_resource_mut::<BoneGizmoData>() {
                     gizmo.visible = *visible;
+                }
+            }
+            UIEvent::SetWeightHeatmapEnabled(enabled) => {
+                log!("UIEvent::SetWeightHeatmapEnabled({})", enabled);
+                if let Some(mut heatmap) = world.get_resource_mut::<WeightHeatmapState>() {
+                    heatmap.enabled = *enabled;
+                } else {
+                    log_warn!("WeightHeatmapState resource missing when toggling heatmap");
                 }
             }
             UIEvent::SetTransformGizmoMode(mode) => {

--- a/src/ecs/systems/phases/event_dispatch_phase.rs
+++ b/src/ecs/systems/phases/event_dispatch_phase.rs
@@ -33,8 +33,10 @@ pub fn run_event_dispatch_phase(
     #[cfg(feature = "text-to-motion")]
     super::dispatch_ml::drain_grpc_responses(world, assets);
 
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     super::dispatch_ml::poll_mesh_server_status(world);
+    #[cfg(feature = "auto-rig")]
+    super::dispatch_ml::poll_rigging_server_status(world);
 
     let events: Vec<UIEvent> = {
         if let Some(mut ui_events) = world.get_resource_mut::<UIEventQueue>() {
@@ -71,8 +73,10 @@ pub fn run_event_dispatch_phase(
     let mut deferred = dispatch_camera_light_debug_events(&events, world, model_bounds);
     deferred.extend(hierarchy_deferred);
 
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     super::dispatch_ml::dispatch_text_to_mesh_events(&events, world, &mut deferred);
+    #[cfg(feature = "auto-rig")]
+    super::dispatch_ml::dispatch_auto_rig_events(&events, world, &mut deferred);
 
     let platform_events = filter_platform_events(&events);
 

--- a/src/ecs/systems/phases/input_phase.rs
+++ b/src/ecs/systems/phases/input_phase.rs
@@ -11,11 +11,12 @@ use crate::ecs::resource::gizmo::{BoneDisplayStyle, BoneGizmoData, TransformGizm
 use crate::ecs::resource::CurveEditorState;
 use crate::ecs::resource::{
     BonePoseOverride, ClipLibrary, HierarchyDisplayMode, ImGuiInputCapture, KeyboardModifiers,
-    MouseInput, TimelineState, TransformGizmoMode, TransformGizmoState, ViewportInput,
+    MeshAssets, MouseInput, TimelineState, TransformGizmoMode, TransformGizmoState, ViewportInput,
 };
 use crate::ecs::systems::{
     compute_local_override_from_global_rotation, compute_local_override_from_global_scale,
-    compute_local_override_from_global_translation, select_bone_by_ray, transform_gizmo_systems,
+    compute_local_override_from_global_translation, select_bone_by_mesh_ray, select_bone_by_ray,
+    transform_gizmo_systems,
 };
 use crate::ecs::world::{Entity, GlobalTransform, Transform};
 use crate::ecs::{
@@ -304,7 +305,7 @@ fn process_bone_selection(ctx: &mut EcsContext) -> Result<bool> {
     };
     let skeleton = skeleton_ref.clone();
 
-    let hit = select_bone_by_ray(
+    let widget_hit = select_bone_by_ray(
         ray_origin,
         ray_direction,
         &skeleton,
@@ -313,6 +314,12 @@ fn process_bone_selection(ctx: &mut EcsContext) -> Result<bool> {
         mesh_scale,
         None,
     );
+
+    let hit = widget_hit.or_else(|| {
+        let entity_transform = find_animated_entity_transform(ctx.world)?;
+        let mesh_assets = ctx.world.resource::<MeshAssets>();
+        select_bone_by_mesh_ray(ray_origin, ray_direction, &mesh_assets, entity_transform)
+    });
 
     let bone_hit = hit.is_some();
 
@@ -995,6 +1002,15 @@ fn sync_curve_editor_bone(ctx: &mut EcsContext, new_active_bone: Option<BoneId>)
         let mut editor = ctx.world.resource_mut::<CurveEditorState>();
         editor.selected_bone_id = Some(bone_id);
     }
+}
+
+fn find_animated_entity_transform(world: &crate::ecs::World) -> Option<Matrix4<f32>> {
+    use crate::ecs::world::{Animator, GlobalTransform};
+
+    let (entity, _) = world.iter_components::<Animator>().next()?;
+    world
+        .get_component::<GlobalTransform>(entity)
+        .map(|gt| gt.0)
 }
 
 fn compute_animation_globals(

--- a/src/ecs/systems/ui_event_systems.rs
+++ b/src/ecs/systems/ui_event_systems.rs
@@ -23,7 +23,7 @@ pub enum DeferredAction {
         baked_id: u64,
         path: PathBuf,
     },
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     LoadModelFromMemory {
         glb_data: Vec<u8>,
     },

--- a/src/ecs/systems/weight_heatmap_systems.rs
+++ b/src/ecs/systems/weight_heatmap_systems.rs
@@ -1,0 +1,354 @@
+use cgmath::{Vector3, Vector4};
+
+use crate::animation::{BoneId, SkinData};
+use crate::ecs::resource::gizmo::BoneSelectionState;
+use crate::ecs::resource::{HeatmapApplication, WeightHeatmapState};
+use crate::math::Vec4;
+use crate::vulkanr::data::Vertex;
+use crate::vulkanr::resource::graphics_resource::GraphicsResources;
+use crate::vulkanr::resource::mesh_buffer::MeshBuffer;
+
+pub fn update_weight_heatmap(
+    graphics: &mut GraphicsResources,
+    heatmap: &mut WeightHeatmapState,
+    selection: &BoneSelectionState,
+) -> Vec<usize> {
+    let desired = if heatmap.enabled {
+        HeatmapApplication::Applied(selection.active_bone_index.map(|i| i as BoneId))
+    } else {
+        HeatmapApplication::NotApplied
+    };
+
+    if &desired == heatmap.last_applied() {
+        return Vec::new();
+    }
+
+    log!(
+        "WeightHeatmap: state transition {:?} -> {:?} (meshes={})",
+        heatmap.last_applied(),
+        desired,
+        graphics.meshes.len()
+    );
+
+    let mut changed_meshes = Vec::new();
+    let mut skipped_no_base_colors = 0;
+    let mut skipped_length_mismatch = 0;
+    for (mesh_index, mesh) in graphics.meshes.iter_mut().enumerate() {
+        match update_mesh_colors(mesh, &desired) {
+            MeshUpdateOutcome::Updated => changed_meshes.push(mesh_index),
+            MeshUpdateOutcome::SkippedNoBaseColors => skipped_no_base_colors += 1,
+            MeshUpdateOutcome::SkippedLengthMismatch => skipped_length_mismatch += 1,
+        }
+    }
+
+    log!(
+        "WeightHeatmap: updated={}, skipped_no_base_colors={}, skipped_length_mismatch={}",
+        changed_meshes.len(),
+        skipped_no_base_colors,
+        skipped_length_mismatch
+    );
+
+    heatmap.set_last_applied(desired);
+    changed_meshes
+}
+
+enum MeshUpdateOutcome {
+    Updated,
+    SkippedNoBaseColors,
+    SkippedLengthMismatch,
+}
+
+fn update_mesh_colors(mesh: &mut MeshBuffer, desired: &HeatmapApplication) -> MeshUpdateOutcome {
+    let MeshBuffer {
+        vertex_data,
+        base_colors,
+        skin_data,
+        ..
+    } = mesh;
+    let Some(base_colors) = base_colors.as_ref() else {
+        return MeshUpdateOutcome::SkippedNoBaseColors;
+    };
+    if base_colors.len() != vertex_data.vertices.len() {
+        return MeshUpdateOutcome::SkippedLengthMismatch;
+    }
+
+    let target_bone = match desired {
+        HeatmapApplication::Applied(bone_opt) => *bone_opt,
+        HeatmapApplication::NotApplied => None,
+    };
+
+    match (desired, target_bone, skin_data.as_ref()) {
+        (HeatmapApplication::Applied(_), Some(bone_id), Some(skin)) => {
+            apply_heatmap_to_vertices(&mut vertex_data.vertices, skin, base_colors, bone_id);
+        }
+        _ => {
+            restore_base_colors(&mut vertex_data.vertices, base_colors);
+        }
+    }
+    MeshUpdateOutcome::Updated
+}
+
+fn apply_heatmap_to_vertices(
+    vertices: &mut [Vertex],
+    skin: &SkinData,
+    base_colors: &[Vector4<f32>],
+    bone_id: BoneId,
+) {
+    debug_assert_eq!(vertices.len(), skin.bone_indices.len());
+    debug_assert_eq!(vertices.len(), skin.bone_weights.len());
+    debug_assert_eq!(vertices.len(), base_colors.len());
+
+    for i in 0..vertices.len() {
+        let weight = extract_weight_for_bone(&skin.bone_indices[i], &skin.bone_weights[i], bone_id);
+        let rgb = weight_to_heatmap_rgb(weight);
+        let base_alpha = base_colors[i].w;
+        vertices[i].color = Vec4::new(rgb.x, rgb.y, rgb.z, base_alpha);
+    }
+}
+
+fn restore_base_colors(vertices: &mut [Vertex], base_colors: &[Vector4<f32>]) {
+    debug_assert_eq!(vertices.len(), base_colors.len());
+    for (i, base) in base_colors.iter().enumerate() {
+        vertices[i].color = Vec4::new(base.x, base.y, base.z, base.w);
+    }
+}
+
+fn extract_weight_for_bone(indices: &Vector4<u32>, weights: &Vector4<f32>, bone_id: BoneId) -> f32 {
+    let slots = [
+        (indices.x, weights.x),
+        (indices.y, weights.y),
+        (indices.z, weights.z),
+        (indices.w, weights.w),
+    ];
+    slots
+        .iter()
+        .filter(|(bone, _)| *bone == bone_id)
+        .map(|(_, weight)| *weight)
+        .sum()
+}
+
+fn weight_to_heatmap_rgb(w: f32) -> Vector3<f32> {
+    let w = w.clamp(0.0, 1.0);
+    let stops = [
+        (0.00_f32, Vector3::new(0.0, 0.0, 1.0)),
+        (0.25_f32, Vector3::new(0.0, 1.0, 1.0)),
+        (0.50_f32, Vector3::new(0.0, 1.0, 0.0)),
+        (0.75_f32, Vector3::new(1.0, 1.0, 0.0)),
+        (1.00_f32, Vector3::new(1.0, 0.0, 0.0)),
+    ];
+    for window in stops.windows(2) {
+        let (t0, c0) = window[0];
+        let (t1, c1) = window[1];
+        if w <= t1 {
+            let k = (w - t0) / (t1 - t0);
+            return c0 * (1.0 - k) + c1 * k;
+        }
+    }
+    stops[stops.len() - 1].1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx_eq_vec3(a: Vector3<f32>, b: Vector3<f32>) -> bool {
+        (a.x - b.x).abs() < 1e-5 && (a.y - b.y).abs() < 1e-5 && (a.z - b.z).abs() < 1e-5
+    }
+
+    #[test]
+    fn weight_to_heatmap_rgb_returns_blue_at_zero() {
+        let color = weight_to_heatmap_rgb(0.0);
+        assert!(approx_eq_vec3(color, Vector3::new(0.0, 0.0, 1.0)));
+    }
+
+    #[test]
+    fn weight_to_heatmap_rgb_returns_red_at_one() {
+        let color = weight_to_heatmap_rgb(1.0);
+        assert!(approx_eq_vec3(color, Vector3::new(1.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn weight_to_heatmap_rgb_returns_green_at_half() {
+        let color = weight_to_heatmap_rgb(0.5);
+        assert!(approx_eq_vec3(color, Vector3::new(0.0, 1.0, 0.0)));
+    }
+
+    #[test]
+    fn weight_to_heatmap_rgb_clamps_below_zero() {
+        let color = weight_to_heatmap_rgb(-0.5);
+        assert!(approx_eq_vec3(color, Vector3::new(0.0, 0.0, 1.0)));
+    }
+
+    #[test]
+    fn weight_to_heatmap_rgb_clamps_above_one() {
+        let color = weight_to_heatmap_rgb(2.0);
+        assert!(approx_eq_vec3(color, Vector3::new(1.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn extract_weight_for_bone_returns_matching_slot() {
+        let indices = Vector4::new(0, 3, 5, 7);
+        let weights = Vector4::new(0.1, 0.4, 0.3, 0.2);
+
+        assert!((extract_weight_for_bone(&indices, &weights, 3) - 0.4).abs() < 1e-6);
+        assert!((extract_weight_for_bone(&indices, &weights, 5) - 0.3).abs() < 1e-6);
+    }
+
+    #[test]
+    fn extract_weight_for_bone_returns_zero_when_not_present() {
+        let indices = Vector4::new(0, 1, 2, 3);
+        let weights = Vector4::new(0.25, 0.25, 0.25, 0.25);
+
+        assert!(extract_weight_for_bone(&indices, &weights, 99).abs() < 1e-6);
+    }
+
+    #[test]
+    fn extract_weight_for_bone_sums_duplicate_slots() {
+        let indices = Vector4::new(5, 5, 3, 1);
+        let weights = Vector4::new(0.2, 0.3, 0.4, 0.1);
+
+        assert!((extract_weight_for_bone(&indices, &weights, 5) - 0.5).abs() < 1e-6);
+    }
+
+    fn make_skin_single_bone(vertex_count: usize, bone_id: BoneId) -> SkinData {
+        let mut skin = SkinData::default();
+        skin.bone_indices = vec![Vector4::new(bone_id, 0, 0, 0); vertex_count];
+        skin.bone_weights = vec![Vector4::new(1.0, 0.0, 0.0, 0.0); vertex_count];
+        skin.base_positions = vec![Vector3::new(0.0, 0.0, 0.0); vertex_count];
+        skin.base_normals = vec![Vector3::new(0.0, 1.0, 0.0); vertex_count];
+        skin
+    }
+
+    #[test]
+    fn apply_heatmap_to_vertices_writes_red_for_full_weight() {
+        let mut vertices = vec![Vertex::default(); 3];
+        let skin = make_skin_single_bone(3, 5);
+        let base_colors = vec![Vector4::new(0.9, 0.8, 0.7, 0.5); 3];
+
+        apply_heatmap_to_vertices(&mut vertices, &skin, &base_colors, 5);
+
+        for vertex in &vertices {
+            assert!((vertex.color.x - 1.0).abs() < 1e-5);
+            assert!(vertex.color.y.abs() < 1e-5);
+            assert!(vertex.color.z.abs() < 1e-5);
+            assert!((vertex.color.w - 0.5).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn apply_heatmap_to_vertices_writes_blue_for_non_matching_bone() {
+        let mut vertices = vec![Vertex::default(); 3];
+        let skin = make_skin_single_bone(3, 5);
+        let base_colors = vec![Vector4::new(0.9, 0.8, 0.7, 1.0); 3];
+
+        apply_heatmap_to_vertices(&mut vertices, &skin, &base_colors, 99);
+
+        for vertex in &vertices {
+            assert!(vertex.color.x.abs() < 1e-5);
+            assert!(vertex.color.y.abs() < 1e-5);
+            assert!((vertex.color.z - 1.0).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn restore_base_colors_copies_exact_values() {
+        let mut vertices = vec![Vertex::default(); 2];
+        vertices[0].color = Vec4::new(1.0, 0.0, 0.0, 1.0);
+        vertices[1].color = Vec4::new(0.0, 1.0, 0.0, 1.0);
+
+        let base_colors = vec![
+            Vector4::new(0.1, 0.2, 0.3, 0.4),
+            Vector4::new(0.5, 0.6, 0.7, 0.8),
+        ];
+
+        restore_base_colors(&mut vertices, &base_colors);
+
+        assert!((vertices[0].color.x - 0.1).abs() < 1e-5);
+        assert!((vertices[0].color.w - 0.4).abs() < 1e-5);
+        assert!((vertices[1].color.z - 0.7).abs() < 1e-5);
+        assert!((vertices[1].color.w - 0.8).abs() < 1e-5);
+    }
+
+    fn build_graphics_with_single_skinned_mesh(bone_id: BoneId) -> GraphicsResources {
+        let mut graphics = GraphicsResources::default();
+        let mut mesh = MeshBuffer::default();
+
+        let vertex_count = 3;
+        mesh.vertex_data.vertices = vec![Vertex::default(); vertex_count];
+        mesh.skin_data = Some(make_skin_single_bone(vertex_count, bone_id));
+        mesh.base_colors = Some(vec![Vector4::new(0.2, 0.2, 0.2, 1.0); vertex_count]);
+
+        graphics.meshes.push(mesh);
+        graphics
+    }
+
+    #[test]
+    fn update_weight_heatmap_is_idempotent_when_state_unchanged() {
+        let mut graphics = build_graphics_with_single_skinned_mesh(5);
+        let mut heatmap = WeightHeatmapState::default();
+        let mut selection = BoneSelectionState::default();
+        heatmap.enabled = true;
+        selection.active_bone_index = Some(5);
+
+        let first = update_weight_heatmap(&mut graphics, &mut heatmap, &selection);
+        let second = update_weight_heatmap(&mut graphics, &mut heatmap, &selection);
+
+        assert_eq!(first.len(), 1);
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn update_weight_heatmap_applies_red_when_enabled_with_matching_bone() {
+        let mut graphics = build_graphics_with_single_skinned_mesh(5);
+        let mut heatmap = WeightHeatmapState::default();
+        let mut selection = BoneSelectionState::default();
+        heatmap.enabled = true;
+        selection.active_bone_index = Some(5);
+
+        update_weight_heatmap(&mut graphics, &mut heatmap, &selection);
+
+        for vertex in &graphics.meshes[0].vertex_data.vertices {
+            assert!((vertex.color.x - 1.0).abs() < 1e-5);
+        }
+        assert_eq!(
+            heatmap.last_applied(),
+            &HeatmapApplication::Applied(Some(5))
+        );
+    }
+
+    #[test]
+    fn update_weight_heatmap_restores_base_colors_when_disabled() {
+        let mut graphics = build_graphics_with_single_skinned_mesh(5);
+        let mut heatmap = WeightHeatmapState::default();
+        let mut selection = BoneSelectionState::default();
+
+        heatmap.enabled = true;
+        selection.active_bone_index = Some(5);
+        update_weight_heatmap(&mut graphics, &mut heatmap, &selection);
+
+        heatmap.enabled = false;
+        let changed = update_weight_heatmap(&mut graphics, &mut heatmap, &selection);
+
+        assert_eq!(changed.len(), 1);
+        for vertex in &graphics.meshes[0].vertex_data.vertices {
+            assert!((vertex.color.x - 0.2).abs() < 1e-5);
+            assert!((vertex.color.w - 1.0).abs() < 1e-5);
+        }
+        assert_eq!(heatmap.last_applied(), &HeatmapApplication::NotApplied);
+    }
+
+    #[test]
+    fn update_weight_heatmap_enabled_with_no_selection_restores_base_colors() {
+        let mut graphics = build_graphics_with_single_skinned_mesh(5);
+        let mut heatmap = WeightHeatmapState::default();
+        let selection = BoneSelectionState::default();
+        heatmap.enabled = true;
+
+        update_weight_heatmap(&mut graphics, &mut heatmap, &selection);
+
+        for vertex in &graphics.meshes[0].vertex_data.vertices {
+            assert!((vertex.color.x - 0.2).abs() < 1e-5);
+        }
+        assert_eq!(heatmap.last_applied(), &HeatmapApplication::Applied(None));
+    }
+}

--- a/src/grpc/grpc_thread.rs
+++ b/src/grpc/grpc_thread.rs
@@ -70,8 +70,10 @@ async fn run_grpc_loop(
     res_tx: mpsc::Sender<GrpcResponse>,
 ) {
     let mut motion_client: Option<MotionGrpcClient> = None;
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     let mut mesh_client: Option<MeshGrpcClient> = None;
+    #[cfg(feature = "auto-rig")]
+    let mut rigging_client: Option<RiggingGrpcClient> = None;
 
     while let Ok(request) = req_rx.recv() {
         match request {
@@ -85,14 +87,24 @@ async fn run_grpc_loop(
                 handle_generate_motion(endpoint, &mut motion_client, &res_tx, req).await;
             }
 
-            #[cfg(feature = "text-to-mesh")]
+            #[cfg(feature = "auto-rig")]
             GrpcRequest::CheckMeshStatus => {
                 handle_check_mesh_status(endpoint, &mut mesh_client, &res_tx).await;
             }
 
-            #[cfg(feature = "text-to-mesh")]
+            #[cfg(feature = "auto-rig")]
             GrpcRequest::GenerateMesh(req) => {
                 handle_generate_mesh(endpoint, &mut mesh_client, &res_tx, req).await;
+            }
+
+            #[cfg(feature = "auto-rig")]
+            GrpcRequest::CheckRiggingStatus => {
+                handle_check_rigging_status(endpoint, &mut rigging_client, &res_tx).await;
+            }
+
+            #[cfg(feature = "auto-rig")]
+            GrpcRequest::GenerateRig(req) => {
+                handle_generate_rig(endpoint, &mut rigging_client, &res_tx, req).await;
             }
         }
     }
@@ -101,9 +113,13 @@ async fn run_grpc_loop(
 type MotionGrpcClient =
     proto::text_to_motion_service_client::TextToMotionServiceClient<tonic::transport::Channel>;
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 type MeshGrpcClient =
     proto::mesh_generation_service_client::MeshGenerationServiceClient<tonic::transport::Channel>;
+
+#[cfg(feature = "auto-rig")]
+type RiggingGrpcClient =
+    proto::auto_rigging_service_client::AutoRiggingServiceClient<tonic::transport::Channel>;
 
 async fn ensure_connected(
     endpoint: &str,
@@ -138,7 +154,7 @@ async fn ensure_connected(
     }
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 async fn ensure_mesh_connected(
     endpoint: &str,
     client: &mut Option<MeshGrpcClient>,
@@ -248,7 +264,7 @@ async fn handle_generate_motion(
     }
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 async fn handle_check_mesh_status(
     endpoint: &str,
     client: &mut Option<MeshGrpcClient>,
@@ -279,7 +295,7 @@ async fn handle_check_mesh_status(
     }
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 async fn handle_generate_mesh(
     endpoint: &str,
     client: &mut Option<MeshGrpcClient>,
@@ -351,6 +367,129 @@ async fn handle_generate_mesh(
             *client = None;
             let _ = res_tx.send(GrpcResponse::Error {
                 message: format!("GenerateMesh failed: {}", e),
+            });
+        }
+    }
+}
+
+#[cfg(feature = "auto-rig")]
+async fn ensure_rigging_connected(
+    endpoint: &str,
+    client: &mut Option<RiggingGrpcClient>,
+    res_tx: &mpsc::Sender<GrpcResponse>,
+) -> bool {
+    if client.is_some() {
+        return true;
+    }
+
+    match tonic::transport::Channel::from_shared(endpoint.to_string()) {
+        Ok(channel_builder) => match channel_builder.connect().await {
+            Ok(channel) => {
+                *client = Some(
+                    proto::auto_rigging_service_client::AutoRiggingServiceClient::new(channel)
+                        .max_decoding_message_size(64 * 1024 * 1024),
+                );
+                true
+            }
+            Err(e) => {
+                let _ = res_tx.send(GrpcResponse::Error {
+                    message: format!("Failed to connect to {}: {}", endpoint, e),
+                });
+                false
+            }
+        },
+        Err(e) => {
+            let _ = res_tx.send(GrpcResponse::Error {
+                message: format!("Invalid endpoint '{}': {}", endpoint, e),
+            });
+            false
+        }
+    }
+}
+
+#[cfg(feature = "auto-rig")]
+async fn handle_check_rigging_status(
+    endpoint: &str,
+    client: &mut Option<RiggingGrpcClient>,
+    res_tx: &mpsc::Sender<GrpcResponse>,
+) {
+    if !ensure_rigging_connected(endpoint, client, res_tx).await {
+        return;
+    }
+
+    let c = client
+        .as_mut()
+        .expect("ensure_rigging_connected returned true so client is Some");
+    let request = tonic::Request::new(proto::RiggingStatusRequest {});
+
+    match c.get_rigging_status(request).await {
+        Ok(response) => {
+            let status = response.into_inner();
+            let _ = res_tx.send(GrpcResponse::RiggingServerStatus {
+                ready: status.ready,
+                model_name: status.model_name,
+                gpu_memory_mb: status.gpu_memory_mb,
+            });
+        }
+        Err(e) => {
+            *client = None;
+            let _ = res_tx.send(GrpcResponse::Error {
+                message: format!("GetRiggingStatus failed: {}", e),
+            });
+        }
+    }
+}
+
+#[cfg(feature = "auto-rig")]
+async fn handle_generate_rig(
+    endpoint: &str,
+    client: &mut Option<RiggingGrpcClient>,
+    res_tx: &mpsc::Sender<GrpcResponse>,
+    req: super::request::RiggingRequest,
+) {
+    if !ensure_rigging_connected(endpoint, client, res_tx).await {
+        return;
+    }
+
+    let c = client
+        .as_mut()
+        .expect("ensure_rigging_connected returned true so client is Some");
+
+    let proto_request = proto::RiggingRequest {
+        glb_data: req.glb_data,
+        params: Some(proto::RiggingParams {
+            num_sample_points: req.num_sample_points as i32,
+        }),
+        model_type: proto::RiggingModelType::RiggingUnirig as i32,
+    };
+
+    match c.generate_rig(tonic::Request::new(proto_request)).await {
+        Ok(response) => {
+            let resp = response.into_inner();
+            let metadata = resp.metadata.unwrap_or_default();
+            let joints = resp
+                .skeleton_joints
+                .into_iter()
+                .map(|j| super::request::SkeletonJointInfo {
+                    name: j.name,
+                    position: [j.x, j.y, j.z],
+                    tail: [j.tail_x, j.tail_y, j.tail_z],
+                    parent_index: j.parent_index,
+                })
+                .collect();
+
+            let _ = res_tx.send(GrpcResponse::RigGenerated {
+                rigged_glb_data: resp.rigged_glb_data,
+                joint_count: metadata.joint_count as u32,
+                bone_count: metadata.bone_count as u32,
+                generation_time_ms: metadata.generation_time_ms,
+                skeleton_joints: joints,
+            });
+        }
+        Err(e) => {
+            *client = None;
+            let _ = res_tx.send(GrpcResponse::Error {
+                message: format!("GenerateRig failed: {}", e),
             });
         }
     }

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1,11 +1,11 @@
 mod grpc_thread;
 mod request;
 mod response_converter;
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 mod server_launcher;
 
 pub use grpc_thread::*;
 pub use request::*;
 pub use response_converter::*;
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub use server_launcher::*;

--- a/src/grpc/request.rs
+++ b/src/grpc/request.rs
@@ -4,14 +4,14 @@ pub struct TextToMotionRequest {
     pub target_fps: i32,
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MeshInputMode {
     TextOnly,
     Image,
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MeshModelType {
     Trellis,
@@ -21,7 +21,7 @@ pub enum MeshModelType {
     Era3D,
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TextToImageModelType {
     ServerDefault,
@@ -29,7 +29,7 @@ pub enum TextToImageModelType {
     Animagine,
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 impl MeshModelType {
     pub const IMAGE_VARIANTS: &[MeshModelType] = &[
         MeshModelType::Trellis,
@@ -65,7 +65,7 @@ impl MeshModelType {
     }
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 impl TextToImageModelType {
     pub const ALL_VARIANTS: &[TextToImageModelType] = &[
         TextToImageModelType::ServerDefault,
@@ -82,7 +82,7 @@ impl TextToImageModelType {
     }
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub struct TextToMeshRequest {
     pub prompt: String,
     pub target_faces: u32,
@@ -93,13 +93,31 @@ pub struct TextToMeshRequest {
     pub t2i_model_type: TextToImageModelType,
 }
 
+#[cfg(feature = "auto-rig")]
+pub struct RiggingRequest {
+    pub glb_data: Vec<u8>,
+    pub num_sample_points: u32,
+}
+
+#[cfg(feature = "auto-rig")]
+pub struct SkeletonJointInfo {
+    pub name: String,
+    pub position: [f32; 3],
+    pub tail: [f32; 3],
+    pub parent_index: i32,
+}
+
 pub enum GrpcRequest {
     GenerateMotion(TextToMotionRequest),
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     GenerateMesh(TextToMeshRequest),
+    #[cfg(feature = "auto-rig")]
+    GenerateRig(RiggingRequest),
     CheckStatus,
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     CheckMeshStatus,
+    #[cfg(feature = "auto-rig")]
+    CheckRiggingStatus,
     Shutdown,
 }
 
@@ -109,7 +127,7 @@ pub enum GrpcResponse {
         generation_time_ms: f32,
         model_used: String,
     },
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     MeshGenerated {
         glb_data: Vec<u8>,
         vertex_count: u32,
@@ -122,9 +140,23 @@ pub enum GrpcResponse {
         active_model: String,
         gpu_memory_mb: i32,
     },
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     MeshServerStatus {
         ready: bool,
+    },
+    #[cfg(feature = "auto-rig")]
+    RigGenerated {
+        rigged_glb_data: Vec<u8>,
+        joint_count: u32,
+        bone_count: u32,
+        generation_time_ms: f32,
+        skeleton_joints: Vec<SkeletonJointInfo>,
+    },
+    #[cfg(feature = "auto-rig")]
+    RiggingServerStatus {
+        ready: bool,
+        model_name: String,
+        gpu_memory_mb: i32,
     },
     Error {
         message: String,

--- a/src/loader/gltf/loader.rs
+++ b/src/loader/gltf/loader.rs
@@ -224,7 +224,7 @@ pub unsafe fn load_gltf_file(path: &str) -> Result<GltfLoadResult> {
     Ok(build_result(ctx))
 }
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub unsafe fn load_gltf_from_slice(data: &[u8]) -> Result<GltfLoadResult> {
     log!("Loading glTF from memory ({} bytes)", data.len());
     let (gltf, buffers, images) = gltf::import_slice(data)?;
@@ -401,38 +401,22 @@ fn determine_skeleton_root_transform(
     skin: &gltf::Skin,
     parent_map: &HashMap<usize, usize>,
 ) -> Option<[[f32; 4]; 4]> {
-    if let Some(skeleton_node) = skin.skeleton() {
-        let global_transform =
-            compute_node_global_transform(gltf, skeleton_node.index(), parent_map);
-        log!(
-            "Skeleton root transform from skin.skeleton: node {} ({:?})",
-            skeleton_node.index(),
-            skeleton_node.name()
-        );
-        return Some(array_from_mat4(global_transform));
-    }
-
     let joint_indices: std::collections::HashSet<usize> =
         skin.joints().map(|j| j.index()).collect();
-    let mut root_joint_node: Option<gltf::Node> = None;
 
-    for joint in skin.joints() {
-        let has_parent_joint = parent_map
+    let root_joint_node = skin.joints().find(|joint| {
+        parent_map
             .get(&joint.index())
-            .map(|parent_idx| joint_indices.contains(parent_idx))
-            .unwrap_or(false);
-
-        if !has_parent_joint {
-            root_joint_node = Some(joint);
-            break;
-        }
-    }
+            .map(|parent_idx| !joint_indices.contains(parent_idx))
+            .unwrap_or(true)
+    });
 
     if let Some(root_joint) = root_joint_node {
         if let Some(&parent_index) = parent_map.get(&root_joint.index()) {
             let parent_global = compute_node_global_transform(gltf, parent_index, parent_map);
             log!(
-                "Skeleton root transform from root joint's parent: node {}",
+                "Skeleton root transform from root joint's parent: joint node {} -> parent node {}",
+                root_joint.index(),
                 parent_index
             );
             return Some(array_from_mat4(parent_global));
@@ -1348,7 +1332,7 @@ fn build_meshes_and_morph(
     for mesh in source_meshes {
         let mut vertex_data = mesh.vertex_data;
 
-        if scale != 1.0 {
+        if scale != 1.0 && !mesh.has_joints {
             for v in &mut vertex_data.vertices {
                 v.pos.x *= scale;
                 v.pos.y *= scale;

--- a/src/loader/gltf/mod.rs
+++ b/src/loader/gltf/mod.rs
@@ -1,6 +1,6 @@
 mod loader;
 pub mod spring_bone_extension;
 
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub use loader::load_gltf_from_slice;
 pub use loader::{load_gltf_file, GltfLoadResult, GltfMeshData, ImageData, NodeInfo};

--- a/src/math/coordinate_system.rs
+++ b/src/math/coordinate_system.rs
@@ -276,6 +276,16 @@ pub fn ray_to_triangle_intersection(
     v1: Vector3<f32>,
     v2: Vector3<f32>,
 ) -> Option<f32> {
+    ray_to_triangle_barycentric(ray_origin, ray_direction, v0, v1, v2).map(|(t, _, _)| t)
+}
+
+pub fn ray_to_triangle_barycentric(
+    ray_origin: Vector3<f32>,
+    ray_direction: Vector3<f32>,
+    v0: Vector3<f32>,
+    v1: Vector3<f32>,
+    v2: Vector3<f32>,
+) -> Option<(f32, f32, f32)> {
     let edge1 = v1 - v0;
     let edge2 = v2 - v0;
     let h = ray_direction.cross(edge2);
@@ -306,7 +316,7 @@ pub fn ray_to_triangle_intersection(
         return None;
     }
 
-    Some(t)
+    Some((t, u, v))
 }
 
 #[cfg(test)]

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -8,8 +8,8 @@ pub use billboard::*;
 pub use coordinate_system::{
     blender_to_world, fbx_to_world, fix_coord, get_camera_axes_from_view, gltf_to_world,
     perspective, ray_plane_intersection, ray_to_line_segment_distance, ray_to_point_distance,
-    ray_to_triangle_intersection, screen_to_world_ray, view, world_to_screen, world_y_axis,
-    world_y_down,
+    ray_to_triangle_barycentric, ray_to_triangle_intersection, screen_to_world_ray, view,
+    world_to_screen, world_y_axis, world_y_down,
 };
 pub use matrix::*;
 pub use quaternion::*;

--- a/src/platform/events.rs
+++ b/src/platform/events.rs
@@ -49,7 +49,7 @@ impl System {
         let mut last_frame = Instant::now();
         let bindings = default_bindings();
         let mut status_bar_state = StatusBarState::default();
-        #[cfg(feature = "text-to-mesh")]
+        #[cfg(feature = "auto-rig")]
         let mut text_to_mesh_dialog_state = crate::platform::ui::TextToMeshDialogState::default();
 
         event_loop
@@ -81,7 +81,7 @@ impl System {
                         &window,
                         &bindings,
                         &mut status_bar_state,
-                        #[cfg(feature = "text-to-mesh")]
+                        #[cfg(feature = "auto-rig")]
                         &mut text_to_mesh_dialog_state,
                     );
                 }
@@ -105,7 +105,7 @@ fn dispatch_window_event(
     window: &winit::window::Window,
     bindings: &[super::key_bindings::KeyBinding],
     status_bar_state: &mut StatusBarState,
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     text_to_mesh_dialog: &mut crate::platform::ui::TextToMeshDialogState,
 ) {
     match event {
@@ -148,7 +148,7 @@ fn dispatch_window_event(
                 window,
                 app,
                 status_bar_state,
-                #[cfg(feature = "text-to-mesh")]
+                #[cfg(feature = "auto-rig")]
                 text_to_mesh_dialog,
             );
         }
@@ -187,7 +187,7 @@ fn handle_redraw_requested(
     window: &winit::window::Window,
     app: &mut App,
     status_bar_state: &mut StatusBarState,
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     text_to_mesh_dialog: &mut crate::platform::ui::TextToMeshDialogState,
 ) {
     let ui = imgui.frame();
@@ -211,7 +211,7 @@ fn handle_redraw_requested(
     let mut overlay_state = SceneOverlayState {
         model_path: model_state.model_path.clone(),
         load_status: model_state.load_status.clone(),
-        #[cfg(feature = "text-to-mesh")]
+        #[cfg(feature = "auto-rig")]
         open_text_to_mesh_dialog: false,
     };
     drop(model_state);
@@ -223,7 +223,7 @@ fn handle_redraw_requested(
         &mut debug_state,
         &mut overlay_state,
         status_bar_state,
-        #[cfg(feature = "text-to-mesh")]
+        #[cfg(feature = "auto-rig")]
         text_to_mesh_dialog,
     );
 
@@ -252,7 +252,7 @@ fn build_ui_windows(
     #[cfg(debug_assertions)] debug_state: &mut DebugWindowState,
     overlay_state: &mut SceneOverlayState,
     status_bar_state: &mut StatusBarState,
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     text_to_mesh_dialog: &mut crate::platform::ui::TextToMeshDialogState,
 ) {
     let display_size = ui.io().display_size;
@@ -286,7 +286,7 @@ fn build_ui_windows(
     build_timeline_and_fixed_overlays(ui, app, status_bar_state, &viewport_info, &layout_snapshot);
     build_curve_editor(ui, app);
 
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     {
         if overlay_state.open_text_to_mesh_dialog {
             text_to_mesh_dialog.open = true;
@@ -649,7 +649,7 @@ unsafe fn execute_deferred_action(app: &mut App, action: DeferredAction) {
             }
         }
 
-        #[cfg(feature = "text-to-mesh")]
+        #[cfg(feature = "auto-rig")]
         DeferredAction::LoadModelFromMemory { glb_data } => {
             match app.load_model_from_glb(&glb_data) {
                 Ok(()) => {}

--- a/src/platform/ui/mod.rs
+++ b/src/platform/ui/mod.rs
@@ -12,7 +12,7 @@ mod panel_splitter;
 mod scene_overlay;
 mod spring_bone_inspector;
 mod status_bar;
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 mod text_to_mesh_dialog;
 #[cfg(feature = "text-to-motion")]
 mod text_to_motion_dialog;
@@ -33,7 +33,7 @@ pub use panel_splitter::*;
 pub use scene_overlay::*;
 pub use spring_bone_inspector::*;
 pub use status_bar::*;
-#[cfg(feature = "text-to-mesh")]
+#[cfg(feature = "auto-rig")]
 pub use text_to_mesh_dialog::*;
 #[cfg(feature = "text-to-motion")]
 pub use text_to_motion_dialog::*;

--- a/src/platform/ui/scene_overlay.rs
+++ b/src/platform/ui/scene_overlay.rs
@@ -13,9 +13,12 @@ const OVERLAY_WIDTH: f32 = 280.0;
 pub struct SceneOverlayState {
     pub model_path: String,
     pub load_status: String,
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     pub open_text_to_mesh_dialog: bool,
 }
+
+#[cfg(feature = "auto-rig")]
+use crate::ecs::resource::{AutoRigState, AutoRigStatus};
 
 pub fn build_scene_overlay(
     ui: &imgui::Ui,
@@ -36,7 +39,7 @@ pub fn build_scene_overlay(
         .focus_on_appearing(false)
         .save_settings(false)
         .build(|| {
-            build_model_section(ui, ui_events, overlay_state);
+            build_model_section(ui, ui_events, overlay_state, ecs_world);
             ui.separator();
 
             build_screenshot_section(ui, ui_events);
@@ -58,6 +61,7 @@ fn build_model_section(
     ui: &imgui::Ui,
     ui_events: &mut UIEventQueue,
     state: &mut SceneOverlayState,
+    _ecs_world: &World,
 ) {
     if ui.button("Open FBX") {
         if let Some(path) = rfd::FileDialog::new()
@@ -96,10 +100,13 @@ fn build_model_section(
         }
     }
 
-    #[cfg(feature = "text-to-mesh")]
+    #[cfg(feature = "auto-rig")]
     if ui.button("Generate Mesh") {
         state.open_text_to_mesh_dialog = true;
     }
+
+    #[cfg(feature = "auto-rig")]
+    build_auto_rig_section(ui, ui_events, _ecs_world);
 
     let model_name = if state.model_path.is_empty() {
         "None"
@@ -108,6 +115,86 @@ fn build_model_section(
     };
     ui.text_wrapped(format!("Model: {}", model_name));
     ui.text(format!("Status: {}", state.load_status));
+}
+
+#[cfg(feature = "auto-rig")]
+fn build_auto_rig_section(ui: &imgui::Ui, ui_events: &mut UIEventQueue, ecs_world: &World) {
+    use crate::ecs::component::GlbSource;
+    use crate::ecs::resource::HierarchyState;
+    use crate::ecs::world::Parent;
+
+    let auto_rig_state = ecs_world.resource::<AutoRigState>();
+    let status = auto_rig_state.status.clone();
+    let joint_count = auto_rig_state.joint_count;
+    let bone_count = auto_rig_state.bone_count;
+    let gen_time = auto_rig_state.generation_time_ms;
+    let error_msg = auto_rig_state.error_message.clone();
+    drop(auto_rig_state);
+
+    match status {
+        AutoRigStatus::Idle => {
+            let hierarchy = ecs_world.resource::<HierarchyState>();
+            let selected = hierarchy.selected_entity;
+            drop(hierarchy);
+
+            let has_glb_source = selected.map_or(false, |entity| {
+                if ecs_world.get_component::<GlbSource>(entity).is_some() {
+                    return true;
+                }
+                if let Some(Parent(parent)) = ecs_world.get_component::<Parent>(entity) {
+                    return ecs_world.get_component::<GlbSource>(*parent).is_some();
+                }
+                false
+            });
+
+            if has_glb_source && ui.button("Auto Rig") {
+                ui_events.send(UIEvent::AutoRigGenerate {
+                    num_sample_points: 65536,
+                });
+            }
+        }
+
+        AutoRigStatus::WaitingForServer => {
+            ui.text("Rigging: waiting for server...");
+            if ui.button("Cancel##rig") {
+                ui_events.send(UIEvent::AutoRigDiscard);
+            }
+        }
+
+        AutoRigStatus::Rigging => {
+            ui.text("Rigging: processing...");
+            if ui.button("Cancel##rig") {
+                ui_events.send(UIEvent::AutoRigDiscard);
+            }
+        }
+
+        AutoRigStatus::Previewing => {
+            if let Some(gen_time) = gen_time {
+                ui.text(format!(
+                    "Preview: {} joints, {} bones ({:.1}s)",
+                    joint_count.unwrap_or(0),
+                    bone_count.unwrap_or(0),
+                    gen_time / 1000.0
+                ));
+            }
+            if ui.button("Apply Rig") {
+                ui_events.send(UIEvent::AutoRigApply);
+            }
+            ui.same_line();
+            if ui.button("Discard##rig") {
+                ui_events.send(UIEvent::AutoRigDiscard);
+            }
+        }
+
+        AutoRigStatus::Error => {
+            if let Some(ref msg) = error_msg {
+                ui.text_colored([1.0, 0.3, 0.3, 1.0], format!("Rig error: {}", msg));
+            }
+            if ui.button("Dismiss##rig") {
+                ui_events.send(UIEvent::AutoRigDiscard);
+            }
+        }
+    }
 }
 
 fn build_screenshot_section(ui: &imgui::Ui, ui_events: &mut UIEventQueue) {

--- a/src/platform/ui/scene_overlay.rs
+++ b/src/platform/ui/scene_overlay.rs
@@ -2,7 +2,9 @@ use imgui::Condition;
 
 use crate::ecs::events::{UIEvent, UIEventQueue};
 use crate::ecs::resource::gizmo::BoneGizmoData;
-use crate::ecs::resource::{CoordinateSpace, TransformGizmoMode, TransformGizmoState};
+use crate::ecs::resource::{
+    CoordinateSpace, TransformGizmoMode, TransformGizmoState, WeightHeatmapState,
+};
 use crate::ecs::World;
 
 use super::viewport_window::ViewportInfo;
@@ -209,6 +211,12 @@ fn build_overlay_section(ui: &imgui::Ui, ui_events: &mut UIEventQueue, ecs_world
             let mut visible = bone_gizmo.visible;
             if ui.checkbox("Show Bones", &mut visible) {
                 ui_events.send(UIEvent::SetBoneGizmoVisible(visible));
+            }
+        }
+        if let Some(heatmap) = ecs_world.get_resource::<WeightHeatmapState>() {
+            let mut enabled = heatmap.enabled;
+            if ui.checkbox("Show Weight Heatmap (selected bone)", &mut enabled) {
+                ui_events.send(UIEvent::SetWeightHeatmapEnabled(enabled));
             }
         }
     }

--- a/src/vulkanr/renderer/deferred/gbuffer.rs
+++ b/src/vulkanr/renderer/deferred/gbuffer.rs
@@ -3,6 +3,7 @@ use vulkanalia::prelude::v1_0::*;
 
 use crate::app::App;
 use crate::asset::AssetStorage;
+use crate::ecs::resource::WeightHeatmapState;
 use crate::ecs::world::MeshRef;
 use crate::ecs::World;
 use crate::vulkanr::core::{Device, RRDevice};
@@ -16,11 +17,15 @@ use crate::vulkanr::resource::{create_image, create_image_view, RRGBuffer};
 #[derive(Clone, Copy, Debug)]
 pub struct GBufferPushConstants {
     pub object_id: u32,
+    pub heatmap_mode: u32,
 }
 
 impl GBufferPushConstants {
-    pub fn new(object_id: u32) -> Self {
-        Self { object_id }
+    pub fn new(object_id: u32, heatmap_mode: u32) -> Self {
+        Self {
+            object_id,
+            heatmap_mode,
+        }
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -72,16 +77,18 @@ mod tests {
 
     #[test]
     fn test_gbuffer_push_constants_size() {
-        assert_eq!(std::mem::size_of::<GBufferPushConstants>(), 4);
+        assert_eq!(std::mem::size_of::<GBufferPushConstants>(), 8);
     }
 
     #[test]
     fn test_gbuffer_push_constants_as_bytes() {
-        let pc = GBufferPushConstants::new(42);
+        let pc = GBufferPushConstants::new(42, 1);
         let bytes = pc.as_bytes();
-        assert_eq!(bytes.len(), 4);
+        assert_eq!(bytes.len(), 8);
         let object_id = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
         assert_eq!(object_id, 42);
+        let heatmap_mode = u32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        assert_eq!(heatmap_mode, 1);
     }
 
     #[test]
@@ -422,7 +429,8 @@ impl<'a> GBufferPass<'a> {
         );
 
         let object_id: u32 = (mesh_index + 1) as u32;
-        let push_constants = GBufferPushConstants::new(object_id);
+        let heatmap_mode = self.resolve_heatmap_mode();
+        let push_constants = GBufferPushConstants::new(object_id, heatmap_mode);
         self.device.cmd_push_constants(
             command_buffer,
             self.pipeline.pipeline_layout,
@@ -435,5 +443,12 @@ impl<'a> GBufferPass<'a> {
             .cmd_draw_indexed(command_buffer, mesh.index_buffer.indices, 1, 0, 0, 0);
 
         Ok(())
+    }
+
+    fn resolve_heatmap_mode(&self) -> u32 {
+        self.ecs_world
+            .get_resource::<WeightHeatmapState>()
+            .map(|state| if state.enabled { 1 } else { 0 })
+            .unwrap_or(0)
     }
 }

--- a/src/vulkanr/resource/mesh_buffer.rs
+++ b/src/vulkanr/resource/mesh_buffer.rs
@@ -1,3 +1,4 @@
+use cgmath::Vector4;
 use vulkanalia::prelude::v1_0::*;
 
 use crate::animation::{SkeletonId, SkinData};
@@ -21,6 +22,7 @@ pub struct MeshBuffer {
     pub skeleton_id: Option<SkeletonId>,
     pub node_index: Option<usize>,
     pub base_vertices: Vec<Vertex>,
+    pub base_colors: Option<Vec<Vector4<f32>>>,
 }
 
 impl Default for MeshBuffer {
@@ -40,6 +42,7 @@ impl Default for MeshBuffer {
             skeleton_id: None,
             node_index: None,
             base_vertices: Vec::new(),
+            base_colors: None,
         }
     }
 }


### PR DESCRIPTION
 Adds an auto-rig inference workflow over gRPC and debug tooling to verify the resulting skin weights.

  - Skeleton-only auto-rig inference — new AutoRigState resource, auto_rig_systems, and dispatch_ml phase coordinate a request/response flow to the Python gRPC
  server that returns a rigged GLB for a selected entity. Adds GlbSource component, animation_ml.proto updates, and scene-overlay UI to trigger rigging.
  - Skin weight heatmap (debug) — WeightHeatmapState resource plus weight_heatmap_systems recolor vertices by per-bone weight; G-buffer fragment shader is
  extended to display heatmap values, and the bone gizmo systems expose a per-bone inspection mode via the input/overlay phases.
  - Auto-create empty editable clip — when a model is loaded without animations but has a skeleton, register a 5s empty EditableAnimationClip so the user can
  scrub the timeline and validate skinning without authoring a clip first.

  Test plan

  - Load a model with no animations → empty "New Animation" clip (5s) appears in the timeline and the model is scrubbable.
  - Trigger auto-rig on a GLB entity → rigged GLB is received and applied; AutoRigStatus transitions Idle → WaitingForServer → Rigging → Previewing without
  error.
  - Toggle the skin weight heatmap → G-buffer renders per-bone weights; selecting a bone isolates its influence correctly.
  - .\build-with-tests.ps1 passes (lib + integration tests).