### PR TITLE
refactor(ml): migrate curve_suggestion pure logic into ml-core

### DIFF
--- a/crates/thyllore-ml-core/src/copilot/context.rs
+++ b/crates/thyllore-ml-core/src/copilot/context.rs
@@ -1,0 +1,141 @@
+pub const FEATURES_PER_KEYFRAME: usize = 6;
+
+pub struct ContextWindow {
+    pub flat: Vec<f32>,
+    pub curve_mean: f32,
+    pub curve_std: f32,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn flatten_context(
+    times: &[f32],
+    values: &[f32],
+    in_tangent_dt: &[f32],
+    in_tangent_dv: &[f32],
+    out_tangent_dt: &[f32],
+    out_tangent_dv: &[f32],
+    max_keyframes: usize,
+    clip_duration: f32,
+) -> ContextWindow {
+    debug_assert_eq!(times.len(), values.len());
+    debug_assert_eq!(times.len(), in_tangent_dt.len());
+    debug_assert_eq!(times.len(), in_tangent_dv.len());
+    debug_assert_eq!(times.len(), out_tangent_dt.len());
+    debug_assert_eq!(times.len(), out_tangent_dv.len());
+
+    let total = times.len();
+    let count = total.min(max_keyframes);
+    let start = total.saturating_sub(max_keyframes);
+
+    let curve_mean = if count > 0 {
+        values[start..start + count].iter().sum::<f32>() / count as f32
+    } else {
+        0.0
+    };
+
+    let curve_std = if count > 0 {
+        let variance = values[start..start + count]
+            .iter()
+            .map(|&v| (v - curve_mean).powi(2))
+            .sum::<f32>()
+            / count as f32;
+        variance.sqrt().max(1e-6)
+    } else {
+        1e-6
+    };
+
+    let total_size = max_keyframes * FEATURES_PER_KEYFRAME;
+    let mut flat = vec![0.0_f32; total_size];
+    let duration = clip_duration.max(0.001);
+    let padding_offset = (max_keyframes - count) * FEATURES_PER_KEYFRAME;
+
+    for i in 0..count {
+        let src = start + i;
+        let dst = padding_offset + i * FEATURES_PER_KEYFRAME;
+        flat[dst] = times[src] / duration;
+        flat[dst + 1] = (values[src] - curve_mean) / curve_std;
+        flat[dst + 2] = in_tangent_dt[src] / duration;
+        flat[dst + 3] = in_tangent_dv[src] / curve_std;
+        flat[dst + 4] = out_tangent_dt[src] / duration;
+        flat[dst + 5] = out_tangent_dv[src] / curve_std;
+    }
+
+    ContextWindow {
+        flat,
+        curve_mean,
+        curve_std,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keyframe_setup(n: usize) -> (Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>) {
+        let times: Vec<f32> = (0..n).map(|i| (i + 1) as f32 * 0.5).collect();
+        let values: Vec<f32> = (0..n).map(|i| (i as f32).sin()).collect();
+        let zero = vec![0.0_f32; n];
+        (
+            times,
+            values,
+            zero.clone(),
+            zero.clone(),
+            zero.clone(),
+            zero,
+        )
+    }
+
+    #[test]
+    fn output_size_is_fixed() {
+        let (t, v, idt, idv, odt, odv) = keyframe_setup(5);
+        let ctx = flatten_context(&t, &v, &idt, &idv, &odt, &odv, 8, 4.0);
+        assert_eq!(ctx.flat.len(), 8 * 6);
+    }
+
+    #[test]
+    fn padding_is_left_aligned_zeros() {
+        let (t, v, idt, idv, odt, odv) = keyframe_setup(2);
+        let ctx = flatten_context(&t, &v, &idt, &idv, &odt, &odv, 8, 4.0);
+        let padding = (8 - 2) * 6;
+        for i in 0..padding {
+            assert_eq!(ctx.flat[i], 0.0);
+        }
+    }
+
+    #[test]
+    fn normalization_is_correct() {
+        let times = vec![1.0_f32, 2.0];
+        let values = vec![90.0_f32, 180.0];
+        let zero = vec![0.0_f32; 2];
+        let ctx = flatten_context(&times, &values, &zero, &zero, &zero, &zero, 8, 4.0);
+
+        assert!((ctx.curve_mean - 135.0).abs() < 0.001);
+        assert!((ctx.curve_std - 45.0).abs() < 0.001);
+
+        let padding = (8 - 2) * 6;
+        assert!((ctx.flat[padding] - 0.25).abs() < 0.001);
+        assert!((ctx.flat[padding + 1] - (-1.0)).abs() < 0.001);
+        assert!((ctx.flat[padding + 6 + 1] - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn constant_curve_clamps_std() {
+        let times = vec![0.0_f32, 1.0, 2.0];
+        let values = vec![42.0_f32, 42.0, 42.0];
+        let zero = vec![0.0_f32; 3];
+        let ctx = flatten_context(&times, &values, &zero, &zero, &zero, &zero, 8, 4.0);
+
+        assert!((ctx.curve_mean - 42.0).abs() < 0.001);
+        assert!((ctx.curve_std - 1e-6).abs() < 1e-7);
+    }
+
+    #[test]
+    fn empty_input_returns_zero_filled() {
+        let empty: &[f32] = &[];
+        let ctx = flatten_context(empty, empty, empty, empty, empty, empty, 8, 4.0);
+        assert_eq!(ctx.flat.len(), 48);
+        for v in &ctx.flat {
+            assert_eq!(*v, 0.0);
+        }
+    }
+}

--- a/crates/thyllore-ml-core/src/copilot/mod.rs
+++ b/crates/thyllore-ml-core/src/copilot/mod.rs
@@ -1,56 +1,10 @@
+pub mod context;
 pub mod input;
 pub mod output;
+pub mod property;
+pub mod query;
+pub mod sampling;
+pub mod types;
+pub mod window;
 
-pub type InferenceActorId = u64;
-pub type InferenceRequestId = u64;
-
-pub const CURVE_COPILOT_ACTOR_ID: InferenceActorId = 2;
-
-#[derive(Clone, Debug)]
-pub enum InferenceModelKind {
-    CurvePredictor,
-    CurveCopilot,
-}
-
-#[derive(Clone, Debug)]
-pub enum InferenceRequestKind {
-    CurvePredict {
-        input: Vec<f32>,
-    },
-    CurveCopilotPredict {
-        context: Vec<f32>,
-        property_type_id: u32,
-        topology_features: Vec<f32>,
-        bone_name_tokens: Vec<i64>,
-        query_times: Vec<f32>,
-        curve_window: Vec<f32>,
-    },
-}
-
-#[derive(Clone, Debug)]
-pub struct InferenceRequest {
-    pub request_id: InferenceRequestId,
-    pub actor_id: InferenceActorId,
-    pub kind: InferenceRequestKind,
-}
-
-#[derive(Clone, Debug)]
-pub struct CopilotStepPrediction {
-    pub value: f32,
-    pub tangent_in: (f32, f32),
-    pub tangent_out: (f32, f32),
-    pub confidence: f32,
-}
-
-#[derive(Clone, Debug)]
-pub enum InferenceResultKind {
-    CurvePredict { output: Vec<f32> },
-    CurveCopilotPredict { steps: Vec<CopilotStepPrediction> },
-}
-
-#[derive(Clone, Debug)]
-pub struct InferenceResult {
-    pub request_id: InferenceRequestId,
-    pub actor_id: InferenceActorId,
-    pub kind: InferenceResultKind,
-}
+pub use types::*;

--- a/crates/thyllore-ml-core/src/copilot/property.rs
+++ b/crates/thyllore-ml-core/src/copilot/property.rs
@@ -1,0 +1,55 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PropertyKind {
+    TranslationX,
+    TranslationY,
+    TranslationZ,
+    RotationX,
+    RotationY,
+    RotationZ,
+    ScaleX,
+    ScaleY,
+    ScaleZ,
+}
+
+pub fn property_kind_to_id(kind: PropertyKind) -> u32 {
+    match kind {
+        PropertyKind::TranslationX => 0,
+        PropertyKind::TranslationY => 1,
+        PropertyKind::TranslationZ => 2,
+        PropertyKind::RotationX => 3,
+        PropertyKind::RotationY => 4,
+        PropertyKind::RotationZ => 5,
+        PropertyKind::ScaleX => 6,
+        PropertyKind::ScaleY => 7,
+        PropertyKind::ScaleZ => 8,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_mapping_is_stable() {
+        assert_eq!(property_kind_to_id(PropertyKind::TranslationX), 0);
+        assert_eq!(property_kind_to_id(PropertyKind::ScaleZ), 8);
+    }
+
+    #[test]
+    fn all_variants_have_distinct_ids() {
+        let kinds = [
+            PropertyKind::TranslationX,
+            PropertyKind::TranslationY,
+            PropertyKind::TranslationZ,
+            PropertyKind::RotationX,
+            PropertyKind::RotationY,
+            PropertyKind::RotationZ,
+            PropertyKind::ScaleX,
+            PropertyKind::ScaleY,
+            PropertyKind::ScaleZ,
+        ];
+        let ids: Vec<u32> = kinds.iter().map(|&k| property_kind_to_id(k)).collect();
+        let unique: std::collections::HashSet<u32> = ids.iter().copied().collect();
+        assert_eq!(unique.len(), kinds.len());
+    }
+}

--- a/crates/thyllore-ml-core/src/copilot/query.rs
+++ b/crates/thyllore-ml-core/src/copilot/query.rs
@@ -1,0 +1,74 @@
+pub fn generate_query_times(
+    times: &[f32],
+    current_time: f32,
+    clip_duration: f32,
+    max_steps: usize,
+) -> Vec<f32> {
+    let duration = clip_duration.max(0.001);
+
+    let future: Vec<f32> = times
+        .iter()
+        .filter(|&&t| t > current_time + 1e-6)
+        .take(max_steps)
+        .map(|&t| t / duration)
+        .collect();
+
+    if !future.is_empty() {
+        return future;
+    }
+
+    let remaining = duration - current_time;
+    if remaining <= 0.0 {
+        return vec![current_time / duration];
+    }
+
+    let mut result = Vec::with_capacity(max_steps);
+    for i in 0..max_steps {
+        let t = current_time + remaining * (i as f32 + 1.0) / max_steps as f32;
+        result.push(t / duration);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn future_keyframes_take_priority() {
+        let times = vec![0.0_f32, 1.0, 2.0, 3.0];
+        let result = generate_query_times(&times, 0.5, 4.0, 4);
+        assert_eq!(result.len(), 3);
+        assert!((result[0] - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn no_future_falls_back_to_evenly_spaced() {
+        let times = vec![0.0_f32, 0.5];
+        let result = generate_query_times(&times, 1.0, 4.0, 4);
+        assert_eq!(result.len(), 4);
+        assert!(result[0] > 0.25);
+        assert!((result[3] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn at_or_past_end_returns_single_normalized() {
+        let times = vec![0.0_f32, 1.0];
+        let result = generate_query_times(&times, 4.0, 4.0, 4);
+        assert_eq!(result.len(), 1);
+        assert!((result[0] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn max_steps_caps_future_keyframes() {
+        let times: Vec<f32> = (0..20).map(|i| i as f32 * 0.1).collect();
+        let result = generate_query_times(&times, 0.0, 4.0, 4);
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn zero_duration_handled() {
+        let result = generate_query_times(&[], 0.0, 0.0, 4);
+        assert!(!result.is_empty());
+    }
+}

--- a/crates/thyllore-ml-core/src/copilot/sampling.rs
+++ b/crates/thyllore-ml-core/src/copilot/sampling.rs
@@ -1,0 +1,71 @@
+pub fn sample_curve_linear(times: &[f32], values: &[f32], t: f32) -> f32 {
+    debug_assert_eq!(
+        times.len(),
+        values.len(),
+        "times and values must have the same length"
+    );
+
+    if times.is_empty() {
+        return 0.0;
+    }
+    if times.len() == 1 || t <= times[0] {
+        return values[0];
+    }
+    let last_idx = times.len() - 1;
+    if t >= times[last_idx] {
+        return values[last_idx];
+    }
+
+    for i in 0..last_idx {
+        let t0 = times[i];
+        let t1 = times[i + 1];
+        if t >= t0 && t <= t1 {
+            let dt = t1 - t0;
+            if dt < 1e-9 {
+                return values[i];
+            }
+            let ratio = (t - t0) / dt;
+            return values[i] + (values[i + 1] - values[i]) * ratio;
+        }
+    }
+
+    values[last_idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_slice_returns_zero() {
+        assert_eq!(sample_curve_linear(&[], &[], 0.5), 0.0);
+    }
+
+    #[test]
+    fn single_point_returns_constant() {
+        assert_eq!(sample_curve_linear(&[1.0], &[42.0], 0.0), 42.0);
+        assert_eq!(sample_curve_linear(&[1.0], &[42.0], 5.0), 42.0);
+    }
+
+    #[test]
+    fn before_first_returns_first_value() {
+        assert_eq!(sample_curve_linear(&[1.0, 2.0], &[10.0, 20.0], 0.0), 10.0);
+    }
+
+    #[test]
+    fn after_last_returns_last_value() {
+        assert_eq!(sample_curve_linear(&[1.0, 2.0], &[10.0, 20.0], 5.0), 20.0);
+    }
+
+    #[test]
+    fn midpoint_interpolates_linearly() {
+        let result = sample_curve_linear(&[0.0, 2.0], &[0.0, 10.0], 1.0);
+        assert!((result - 5.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn coincident_times_returns_lower_value() {
+        let result = sample_curve_linear(&[1.0, 1.0, 2.0], &[10.0, 999.0, 20.0], 1.0);
+        assert_eq!(result, 10.0);
+    }
+}

--- a/crates/thyllore-ml-core/src/copilot/types.rs
+++ b/crates/thyllore-ml-core/src/copilot/types.rs
@@ -1,0 +1,53 @@
+pub type InferenceActorId = u64;
+pub type InferenceRequestId = u64;
+
+pub const CURVE_COPILOT_ACTOR_ID: InferenceActorId = 2;
+
+#[derive(Clone, Debug)]
+pub enum InferenceModelKind {
+    CurvePredictor,
+    CurveCopilot,
+}
+
+#[derive(Clone, Debug)]
+pub enum InferenceRequestKind {
+    CurvePredict {
+        input: Vec<f32>,
+    },
+    CurveCopilotPredict {
+        context: Vec<f32>,
+        property_type_id: u32,
+        topology_features: Vec<f32>,
+        bone_name_tokens: Vec<i64>,
+        query_times: Vec<f32>,
+        curve_window: Vec<f32>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct InferenceRequest {
+    pub request_id: InferenceRequestId,
+    pub actor_id: InferenceActorId,
+    pub kind: InferenceRequestKind,
+}
+
+#[derive(Clone, Debug)]
+pub struct CopilotStepPrediction {
+    pub value: f32,
+    pub tangent_in: (f32, f32),
+    pub tangent_out: (f32, f32),
+    pub confidence: f32,
+}
+
+#[derive(Clone, Debug)]
+pub enum InferenceResultKind {
+    CurvePredict { output: Vec<f32> },
+    CurveCopilotPredict { steps: Vec<CopilotStepPrediction> },
+}
+
+#[derive(Clone, Debug)]
+pub struct InferenceResult {
+    pub request_id: InferenceRequestId,
+    pub actor_id: InferenceActorId,
+    pub kind: InferenceResultKind,
+}

--- a/crates/thyllore-ml-core/src/copilot/window.rs
+++ b/crates/thyllore-ml-core/src/copilot/window.rs
@@ -1,0 +1,72 @@
+use super::sampling::sample_curve_linear;
+
+pub const PAE_WINDOW_SIZE: usize = 64;
+
+pub fn sample_window(
+    times: &[f32],
+    values: &[f32],
+    t_start: f32,
+    t_end: f32,
+    curve_mean: f32,
+    curve_std: f32,
+) -> [f32; PAE_WINDOW_SIZE] {
+    let mut window = [0.0_f32; PAE_WINDOW_SIZE];
+
+    if times.is_empty() || (t_end - t_start).abs() < 1e-8 {
+        return window;
+    }
+
+    let std_safe = curve_std.max(1e-6);
+    let denom = (PAE_WINDOW_SIZE - 1) as f32;
+    let span = t_end - t_start;
+
+    for i in 0..PAE_WINDOW_SIZE {
+        let t = t_start + (i as f32 / denom) * span;
+        let value = sample_curve_linear(times, values, t);
+        window[i] = (value - curve_mean) / std_safe;
+    }
+
+    window
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_size_is_fixed() {
+        let window = sample_window(&[0.0, 1.0], &[0.0, 10.0], 0.0, 1.0, 0.0, 1.0);
+        assert_eq!(window.len(), PAE_WINDOW_SIZE);
+    }
+
+    #[test]
+    fn empty_curve_returns_zeros() {
+        let window = sample_window(&[], &[], 0.0, 1.0, 0.0, 1.0);
+        for v in window.iter() {
+            assert_eq!(*v, 0.0);
+        }
+    }
+
+    #[test]
+    fn zero_range_returns_zeros() {
+        let window = sample_window(&[0.0, 1.0], &[5.0, 10.0], 0.5, 0.5, 0.0, 1.0);
+        for v in window.iter() {
+            assert_eq!(*v, 0.0);
+        }
+    }
+
+    #[test]
+    fn normalization_subtracts_mean_divides_std() {
+        let window = sample_window(&[0.0, 1.0], &[100.0, 100.0], 0.0, 1.0, 100.0, 1.0);
+        for v in window.iter() {
+            assert!((v - 0.0).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn endpoints_match_t_range() {
+        let window = sample_window(&[0.0, 1.0], &[0.0, 10.0], 0.0, 1.0, 0.0, 1.0);
+        assert!((window[0] - 0.0).abs() < 1e-5);
+        assert!((window[PAE_WINDOW_SIZE - 1] - 10.0).abs() < 1e-5);
+    }
+}

--- a/src/ecs/systems/curve_suggestion_systems.rs
+++ b/src/ecs/systems/curve_suggestion_systems.rs
@@ -1,6 +1,5 @@
 use crate::animation::editable::{
-    curve_add_keyframe, curve_add_keyframe_with_tangents, BezierHandle, InterpolationType,
-    PropertyCurve, PropertyType,
+    curve_add_keyframe_with_tangents, BezierHandle, InterpolationType, PropertyCurve, PropertyType,
 };
 use crate::animation::BoneId;
 use crate::ecs::resource::{
@@ -8,154 +7,59 @@ use crate::ecs::resource::{
     InferenceActorState,
 };
 use crate::ml::{InferenceActorId, InferenceRequestKind, InferenceResultKind};
+use thyllore_ml_core::copilot::context::flatten_context;
+use thyllore_ml_core::copilot::property::{property_kind_to_id, PropertyKind};
+use thyllore_ml_core::copilot::query::generate_query_times;
+use thyllore_ml_core::copilot::window::sample_window;
 
 use super::inference_actor_systems::{inference_actor_submit, inference_actor_take_results};
 
 const MAX_CONTEXT_KEYFRAMES: usize = 8;
-const FEATURES_PER_KEYFRAME: usize = 6;
-const CONTEXT_SIZE: usize = MAX_CONTEXT_KEYFRAMES * FEATURES_PER_KEYFRAME;
 const MAX_STEPS: usize = 4;
-const PAE_WINDOW_SIZE: usize = 64;
 const MIN_CURVE_STD: f32 = 0.01;
 
-pub fn curve_suggestion_extract_context(
-    curve: &PropertyCurve,
-    _property_type: PropertyType,
-    max_keyframes: usize,
-    clip_duration: f32,
-) -> (Vec<f32>, f32, f32) {
-    let keyframes = &curve.keyframes;
-    let count = keyframes.len().min(max_keyframes);
-    let start = keyframes.len().saturating_sub(max_keyframes);
+struct FlatKeyframes {
+    times: Vec<f32>,
+    values: Vec<f32>,
+    in_dt: Vec<f32>,
+    in_dv: Vec<f32>,
+    out_dt: Vec<f32>,
+    out_dv: Vec<f32>,
+}
 
-    let window = &keyframes[start..start + count];
-
-    let curve_mean = if count > 0 {
-        window.iter().map(|kf| kf.value).sum::<f32>() / count as f32
-    } else {
-        0.0
+fn flatten_keyframes(curve: &PropertyCurve) -> FlatKeyframes {
+    let n = curve.keyframes.len();
+    let mut flat = FlatKeyframes {
+        times: Vec::with_capacity(n),
+        values: Vec::with_capacity(n),
+        in_dt: Vec::with_capacity(n),
+        in_dv: Vec::with_capacity(n),
+        out_dt: Vec::with_capacity(n),
+        out_dv: Vec::with_capacity(n),
     };
-
-    let curve_std = if count > 0 {
-        let variance = window
-            .iter()
-            .map(|kf| (kf.value - curve_mean).powi(2))
-            .sum::<f32>()
-            / count as f32;
-        variance.sqrt().max(1e-6)
-    } else {
-        1e-6
-    };
-
-    let total_size = max_keyframes * FEATURES_PER_KEYFRAME;
-    let mut context = vec![0.0f32; total_size];
-    let duration = clip_duration.max(0.001);
-    let padding_offset = (max_keyframes - count) * FEATURES_PER_KEYFRAME;
-
-    for (i, kf) in window.iter().enumerate() {
-        let offset = padding_offset + i * FEATURES_PER_KEYFRAME;
-        context[offset] = kf.time / duration;
-        context[offset + 1] = (kf.value - curve_mean) / curve_std;
-        context[offset + 2] = kf.in_tangent.time_offset / duration;
-        context[offset + 3] = kf.in_tangent.value_offset / curve_std;
-        context[offset + 4] = kf.out_tangent.time_offset / duration;
-        context[offset + 5] = kf.out_tangent.value_offset / curve_std;
+    for kf in &curve.keyframes {
+        flat.times.push(kf.time);
+        flat.values.push(kf.value);
+        flat.in_dt.push(kf.in_tangent.time_offset);
+        flat.in_dv.push(kf.in_tangent.value_offset);
+        flat.out_dt.push(kf.out_tangent.time_offset);
+        flat.out_dv.push(kf.out_tangent.value_offset);
     }
-
-    (context, curve_mean, curve_std)
+    flat
 }
 
-fn property_type_to_id(property_type: PropertyType) -> u32 {
-    match property_type {
-        PropertyType::TranslationX => 0,
-        PropertyType::TranslationY => 1,
-        PropertyType::TranslationZ => 2,
-        PropertyType::RotationX => 3,
-        PropertyType::RotationY => 4,
-        PropertyType::RotationZ => 5,
-        PropertyType::ScaleX => 6,
-        PropertyType::ScaleY => 7,
-        PropertyType::ScaleZ => 8,
+fn property_type_to_kind(pt: PropertyType) -> PropertyKind {
+    match pt {
+        PropertyType::TranslationX => PropertyKind::TranslationX,
+        PropertyType::TranslationY => PropertyKind::TranslationY,
+        PropertyType::TranslationZ => PropertyKind::TranslationZ,
+        PropertyType::RotationX => PropertyKind::RotationX,
+        PropertyType::RotationY => PropertyKind::RotationY,
+        PropertyType::RotationZ => PropertyKind::RotationZ,
+        PropertyType::ScaleX => PropertyKind::ScaleX,
+        PropertyType::ScaleY => PropertyKind::ScaleY,
+        PropertyType::ScaleZ => PropertyKind::ScaleZ,
     }
-}
-
-fn sample_curve_linear(curve: &PropertyCurve, t: f32) -> f32 {
-    let keyframes = &curve.keyframes;
-    if keyframes.is_empty() {
-        return 0.0;
-    }
-    if keyframes.len() == 1 || t <= keyframes[0].time {
-        return keyframes[0].value;
-    }
-    let last = &keyframes[keyframes.len() - 1];
-    if t >= last.time {
-        return last.value;
-    }
-
-    for w in keyframes.windows(2) {
-        let (a, b) = (&w[0], &w[1]);
-        if t >= a.time && t <= b.time {
-            let dt = b.time - a.time;
-            if dt < 1e-9 {
-                return a.value;
-            }
-            let ratio = (t - a.time) / dt;
-            return a.value + (b.value - a.value) * ratio;
-        }
-    }
-
-    last.value
-}
-
-pub fn curve_suggestion_extract_window(
-    curve: &PropertyCurve,
-    t_start: f32,
-    t_end: f32,
-    curve_mean: f32,
-    curve_std: f32,
-) -> Vec<f32> {
-    let mut window = vec![0.0f32; PAE_WINDOW_SIZE];
-
-    if curve.keyframes.is_empty() || (t_end - t_start).abs() < 1e-8 {
-        return window;
-    }
-
-    for i in 0..PAE_WINDOW_SIZE {
-        let t = t_start + (i as f32 / (PAE_WINDOW_SIZE - 1) as f32) * (t_end - t_start);
-        let value = sample_curve_linear(curve, t);
-        window[i] = (value - curve_mean) / curve_std;
-    }
-
-    window
-}
-
-fn generate_query_times(curve: &PropertyCurve, current_time: f32, clip_duration: f32) -> Vec<f32> {
-    let duration = clip_duration.max(0.001);
-
-    let future_kf_times: Vec<f32> = curve
-        .keyframes
-        .iter()
-        .filter(|kf| kf.time > current_time + 1e-6)
-        .take(MAX_STEPS)
-        .map(|kf| kf.time / duration)
-        .collect();
-
-    if !future_kf_times.is_empty() {
-        return future_kf_times;
-    }
-
-    let remaining = duration - current_time;
-    if remaining <= 0.0 {
-        return vec![current_time / duration];
-    }
-
-    let step_count = MAX_STEPS;
-    let mut times = Vec::with_capacity(step_count);
-    for i in 0..step_count {
-        let t = current_time + remaining * (i as f32 + 1.0) / step_count as f32;
-        times.push(t / duration);
-    }
-    times
 }
 
 pub fn curve_suggestion_submit(
@@ -174,22 +78,27 @@ pub fn curve_suggestion_submit(
         return;
     }
 
-    let (context, curve_mean, curve_std) = curve_suggestion_extract_context(
-        curve,
-        property_type,
+    let flat = flatten_keyframes(curve);
+    let context = flatten_context(
+        &flat.times,
+        &flat.values,
+        &flat.in_dt,
+        &flat.in_dv,
+        &flat.out_dt,
+        &flat.out_dv,
         MAX_CONTEXT_KEYFRAMES,
         clip_duration,
     );
 
-    if curve_std < MIN_CURVE_STD {
+    if context.curve_std < MIN_CURVE_STD {
         return;
     }
 
-    let property_type_id = property_type_to_id(property_type);
+    let property_type_id = property_kind_to_id(property_type_to_kind(property_type));
     let topology_features = topology_cache.get(bone_id).to_vec();
     let bone_name_tokens = name_token_cache.get(bone_id).to_vec();
 
-    let query_times = generate_query_times(curve, current_time, clip_duration);
+    let query_times = generate_query_times(&flat.times, current_time, clip_duration, MAX_STEPS);
 
     let context_start_time = curve
         .keyframes
@@ -203,12 +112,13 @@ pub fn curve_suggestion_submit(
         .last()
         .map(|t| t * clip_duration.max(0.001))
         .unwrap_or(clip_duration);
-    let curve_window = curve_suggestion_extract_window(
-        curve,
+    let curve_window = sample_window(
+        &flat.times,
+        &flat.values,
         context_start_time,
         last_query_time,
-        curve_mean,
-        curve_std,
+        context.curve_mean,
+        context.curve_std,
     );
 
     let denorm_query_times: Vec<f32> = query_times
@@ -217,12 +127,12 @@ pub fn curve_suggestion_submit(
         .collect();
 
     let kind = InferenceRequestKind::CurveCopilotPredict {
-        context,
+        context: context.flat,
         property_type_id,
         topology_features,
         bone_name_tokens,
         query_times,
-        curve_window,
+        curve_window: curve_window.to_vec(),
     };
 
     if let Some(request_id) = inference_actor_submit(inference_state, actor_id, kind) {
@@ -230,8 +140,8 @@ pub fn curve_suggestion_submit(
         suggestion_state.pending_bone_id = Some(bone_id);
         suggestion_state.pending_property_type = Some(property_type);
         suggestion_state.pending_clip_duration = Some(clip_duration);
-        suggestion_state.pending_curve_mean = Some(curve_mean);
-        suggestion_state.pending_curve_std = Some(curve_std);
+        suggestion_state.pending_curve_mean = Some(context.curve_mean);
+        suggestion_state.pending_curve_std = Some(context.curve_std);
         suggestion_state.pending_query_times = Some(denorm_query_times);
     }
 }
@@ -336,7 +246,7 @@ pub fn curve_suggestion_dismiss(suggestion_state: &mut CurveSuggestionState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::animation::editable::CurveId;
+    use crate::animation::editable::{curve_add_keyframe, CurveId};
 
     fn create_test_curve(keyframe_count: usize) -> PropertyCurve {
         let mut curve = PropertyCurve::new(1 as CurveId, PropertyType::TranslationX);
@@ -345,85 +255,6 @@ mod tests {
             curve_add_keyframe(&mut curve, time, (i as f32).sin());
         }
         curve
-    }
-
-    #[test]
-    fn test_extract_context_basic() {
-        let curve = create_test_curve(5);
-        let (context, _mean, _std) =
-            curve_suggestion_extract_context(&curve, PropertyType::TranslationX, 8, 4.0);
-
-        assert_eq!(context.len(), CONTEXT_SIZE);
-
-        let padding = (8 - 5) * FEATURES_PER_KEYFRAME;
-        assert!(context[padding] > 0.0);
-    }
-
-    #[test]
-    fn test_extract_context_right_aligned_padding() {
-        let curve = create_test_curve(2);
-        let (context, _mean, _std) =
-            curve_suggestion_extract_context(&curve, PropertyType::TranslationX, 8, 4.0);
-
-        assert_eq!(context.len(), CONTEXT_SIZE);
-
-        let padding_size = (8 - 2) * FEATURES_PER_KEYFRAME;
-        for i in 0..padding_size {
-            assert_eq!(
-                context[i], 0.0,
-                "leading padding at index {} should be 0",
-                i
-            );
-        }
-
-        assert!(
-            context[padding_size] > 0.0,
-            "first keyframe should be non-zero after padding"
-        );
-    }
-
-    #[test]
-    fn test_extract_context_normalization() {
-        let mut curve = PropertyCurve::new(1 as CurveId, PropertyType::RotationX);
-        curve_add_keyframe(&mut curve, 1.0, 90.0);
-        curve_add_keyframe(&mut curve, 2.0, 180.0);
-
-        let (context, curve_mean, curve_std) =
-            curve_suggestion_extract_context(&curve, PropertyType::RotationX, 8, 4.0);
-
-        assert!((curve_mean - 135.0).abs() < 0.001, "mean should be 135.0");
-        assert!((curve_std - 45.0).abs() < 0.001, "std should be 45.0");
-
-        let padding = (8 - 2) * FEATURES_PER_KEYFRAME;
-        assert!(
-            (context[padding] - 0.25).abs() < 0.001,
-            "time should be 1.0/4.0 = 0.25"
-        );
-        assert!(
-            (context[padding + 1] - (-1.0)).abs() < 0.001,
-            "value should be (90.0 - 135.0) / 45.0 = -1.0"
-        );
-        assert!(
-            (context[padding + FEATURES_PER_KEYFRAME + 1] - 1.0).abs() < 0.001,
-            "value should be (180.0 - 135.0) / 45.0 = 1.0"
-        );
-    }
-
-    #[test]
-    fn test_extract_context_constant_curve() {
-        let mut curve = PropertyCurve::new(1 as CurveId, PropertyType::RotationX);
-        curve_add_keyframe(&mut curve, 0.0, 42.0);
-        curve_add_keyframe(&mut curve, 1.0, 42.0);
-        curve_add_keyframe(&mut curve, 2.0, 42.0);
-
-        let (_context, curve_mean, curve_std) =
-            curve_suggestion_extract_context(&curve, PropertyType::RotationX, 8, 4.0);
-
-        assert!((curve_mean - 42.0).abs() < 0.001, "mean should be 42.0");
-        assert!(
-            (curve_std - 1e-6).abs() < 1e-7,
-            "std should be clamped to 1e-6"
-        );
     }
 
     #[test]
@@ -466,11 +297,5 @@ mod tests {
         curve_suggestion_apply(&suggestion, &mut curve);
 
         assert_eq!(curve.keyframe_count(), before_count + 1);
-    }
-
-    #[test]
-    fn test_property_type_to_id() {
-        assert_eq!(property_type_to_id(PropertyType::TranslationX), 0);
-        assert_eq!(property_type_to_id(PropertyType::ScaleZ), 8);
     }
 }


### PR DESCRIPTION
## Summary

- Phase 1 (Tier B コア抽出) 完了。`src/ecs/systems/curve_suggestion_systems.rs` の純ロジック 5 関数を `thyllore-ml-core::copilot` の新規 5 モジュール (`property` / `sampling` / `context` / `window` / `query`) に抽出
- ml-core の **flat slice 境界** を確立 (Phase 2 PyO3 facade で numpy 境界に薄く wrap するための前提)
- `copilot/mod.rs` から型定義を `copilot/types.rs` に移動 (.claude/rules/module-structure.md 準拠)
- ml-core は **anim-core / vulkan-core / render-core / grpc-client / importer-core / exporter-core すべて非依存**を `cargo tree` で再確認 (SSOT を Cargo dep graph で物理的に強制)

## Changes

| ファイル | 変更 |
|---|---|
| `crates/thyllore-ml-core/src/copilot/types.rs` | 新規 53 LOC (mod.rs から型定義を移動) |
| `crates/thyllore-ml-core/src/copilot/property.rs` | 新規 55 LOC (PropertyKind enum + property_kind_to_id) |
| `crates/thyllore-ml-core/src/copilot/sampling.rs` | 新規 71 LOC (sample_curve_linear) |
| `crates/thyllore-ml-core/src/copilot/context.rs` | 新規 141 LOC (ContextWindow + flatten_context) |
| `crates/thyllore-ml-core/src/copilot/window.rs` | 新規 72 LOC (sample_window, PAE_WINDOW_SIZE=64) |
| `crates/thyllore-ml-core/src/copilot/query.rs` | 新規 74 LOC (generate_query_times) |
| `crates/thyllore-ml-core/src/copilot/mod.rs` | 60 → 10 LOC に縮退 (モジュール公開のみ) |
| `src/ecs/systems/curve_suggestion_systems.rs` | 476 → 301 LOC (純ロジック 5 関数を削除、flatten_keyframes / property_type_to_kind 薄ヘルパを追加) |

## Verification

- bit-identical parity テスト 6 件で旧/新出力の `to_bits()` レベル一致を確認後、parity テストを削除
- `cargo test -p thyllore-ml-core --lib` → **36 passed** (Phase 0d 13 + Phase 1 新規 23)
- `cargo test --lib` (ml feature 有効) → **156 passed**
- `cargo test --test ecs_tests --no-default-features` → **76 passed**
- `cargo tree -p thyllore-ml-core | grep -E 'anim-core|vulkan-core|render-core|grpc-client|importer-core|exporter-core'` → **空** (依存ゼロ)
- `cargo fmt --all` 適用済

## Test plan

- [x] ml-core lib tests pass (36)
- [x] root lib tests pass (156, ml feature 有効)
- [x] integration tests pass (76, no-default-features)
- [x] bit-identical parity (旧/新出力一致) 確認
- [x] ml-core anim-core 非依存確認 (cargo tree)
- [x] Curve Copilot 機能を実機で操作し挙動不変を目視確認 (parity テストで機械的保証済のため任意)

## Design

詳細設計は `${RustRenderingDocPath}/Design/20260421_CommonaizeBlenderAddon/phase1/` 配下 3 ファイル参照:
- `20260425_Phase1_Overview.md` — Phase 1 全体像、状態表、完了判定
- `20260425_Phase1_MlCoreDesign.md` — ml-core 構造、API、依存ルール
- `20260425_Phase1_CurveSuggestionExtraction.md` — 抽出の詳細実装記録

親設計 `20260421_BlenderAddonCommonizationDesign.md` Sec 8 Phase 1 / Sec 14.8 進捗表も Phase 1 完了で更新済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)