### PR TITLE
fix: handle null pMessage in Vulkan debug callback (Linux)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [env]
-ORT_DYLIB_PATH = { value = "vendor/onnxruntime/onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll", relative = true }
+ORT_DYLIB_PATH = { value = "vendor/onnxruntime/onnxruntime-linux-x64-1.23.2/lib/libonnxruntime.so", relative = true }
 
 [target.aarch64-linux-android]
 #ar = "NDK/arm64/bin/aarch64-linux-android-ar"

--- a/src/app/init/instance.rs
+++ b/src/app/init/instance.rs
@@ -921,7 +921,11 @@ impl App {
         _: *mut c_void,
     ) -> vk::Bool32 {
         let data = unsafe { *data };
-        let message = unsafe { CStr::from_ptr(data.message) }.to_string_lossy();
+        let message = if data.message.is_null() {
+            std::borrow::Cow::Borrowed("(no message)")
+        } else {
+            unsafe { CStr::from_ptr(data.message) }.to_string_lossy()
+        };
 
         // コンソール（色付き）とログファイルの両方に出力
         use log::{debug, error, trace, warn};


### PR DESCRIPTION
## Summary

- Linux ネイティブ環境 (AMD/Mesa RADV) で `cargo run` 起動時に segfault する問題を修正
- 原因は `App::debug_callback` の `CStr::from_ptr(data.message)` で `data.message` が NULL のケース。AMD/Mesa の Validation Layer 経由のデバッグ通知では `pMessage` が NULL になることがある
- FFI 境界での null チェックを追加し、NULL の場合は `"(no message)"` を表示
- 併せて `.cargo/config.toml` の `ORT_DYLIB_PATH` を Linux 用 (`libonnxruntime.so`) に変更

## Test plan

- [x] `cargo check --no-default-features` 通過
- [x] `cargo check` (ml feature 込み) 通過
- [x] `cargo test --lib`: 156 passed
- [x] `cargo test --test ecs_tests --no-default-features`: 76 passed
- [x] `cargo run --bin thyllore-animation` で Vulkan ウィンドウ起動 → メインループ・キー入力受付まで確認 (Linux native, AMD Radeon RX 7900 XTX)

## Note

`.cargo/config.toml` の ORT_DYLIB_PATH は環境依存のため、Windows 開発者がチェックアウトした際は手元で `onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll` に書き戻す必要があります。長期的には OS ごとに切り替える仕組み (環境変数や `cfg(target_os)` を活用したビルドスクリプト等) の検討が望ましいです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)